### PR TITLE
Fix playback for cameras with spaces in names 

### DIFF
--- a/apps/vision/include/pipeline_state.h
+++ b/apps/vision/include/pipeline_state.h
@@ -44,6 +44,14 @@ public:
     inline int64_t a_pts_at_check() const {return _a_pts_at_check;}
     inline void set_a_pts_at_check(int64_t a_pts) {_a_pts_at_check = a_pts;}
 
+    // Returns true if enough time has passed since last play to perform dead check
+    // Playback streams need more time to start than live streams
+    inline bool ready_for_dead_check() const
+    {
+        auto elapsed = std::chrono::steady_clock::now() - _last_play_time;
+        return elapsed > std::chrono::seconds(15);
+    }
+
     inline void update_range(std::chrono::system_clock::time_point start, std::chrono::system_clock::time_point end)
     {
         _range_start = start;
@@ -85,6 +93,7 @@ private:
     std::chrono::system_clock::time_point _last_control_bar_pos;
     std::chrono::system_clock::time_point _range_start;
     std::chrono::system_clock::time_point _range_end;
+    std::chrono::steady_clock::time_point _last_play_time;
 };
 
 }

--- a/apps/vision/source/pipeline_host.cpp
+++ b/apps/vision/source/pipeline_host.cpp
@@ -516,11 +516,15 @@ void pipeline_host::_entry_point()
             {
                 bool found_dead = false;
 
-                if(curr->second->running() && curr->second->last_v_pts() == curr->second->v_pts_at_check())
-                    found_dead = true;
+                // Skip dead check for recently-started pipelines (playback needs time to start)
+                if(curr->second->ready_for_dead_check())
+                {
+                    if(curr->second->running() && curr->second->last_v_pts() == curr->second->v_pts_at_check())
+                        found_dead = true;
 
-                if(curr->second->running() && curr->second->has_audio() && curr->second->last_a_pts() == curr->second->a_pts_at_check())
-                    found_dead = true;
+                    if(curr->second->running() && curr->second->has_audio() && curr->second->last_a_pts() == curr->second->a_pts_at_check())
+                        found_dead = true;
+                }
 
                 if(found_dead)
                 {

--- a/apps/vision/source/pipeline_state.cpp
+++ b/apps/vision/source/pipeline_state.cpp
@@ -172,6 +172,8 @@ void pipeline_state::resize(uint16_t w, uint16_t h)
 
 void pipeline_state::play_live()
 {
+    _last_play_time = steady_clock::now();
+
     vector<r_arg> arguments;
     add_argument(arguments, "url", _si.rtsp_url);
     add_argument(arguments, "protocols", string("tcp"));
@@ -190,16 +192,17 @@ void pipeline_state::play()
     // add bar duration to playhead position and convert to iso 8601 and append to url.
     // set url on source and call play()
 
-    R_LOG_ERROR("PLAY %s", _si.rtsp_url.c_str());
-
     auto playback_duration = _range_end - _last_control_bar_pos;
 
     string url = r_string_utils::format(
         "%s_%s_%s",
         _si.rtsp_url.c_str(),
         r_time_utils::tp_to_iso_8601(_last_control_bar_pos, false).c_str(),
-        r_time_utils::tp_to_iso_8601(_last_control_bar_pos + playback_duration, false).c_str()
+        r_time_utils::tp_to_iso_8601(_range_end, false).c_str()
     );
+    R_LOG_INFO("  Playback URL: %s", url.c_str());
+
+    _last_play_time = steady_clock::now();
 
     vector<r_arg> arguments;
     add_argument(arguments, "url", url);

--- a/libs/r_vss/source/r_recording_context.cpp
+++ b/libs/r_vss/source/r_recording_context.cpp
@@ -316,10 +316,6 @@ r_recording_context::r_recording_context(r_stream_keeper* sk, const r_camera& ca
             this->_has_audio = true;
     });
 
-    //R_LOG_INFO("recording: camera.id=%s, file=%s, rtsp_url=%s", _camera.id.c_str(), _camera.record_file_path.value().c_str(), _camera.rtsp_url.value().c_str());
-    printf("recording: camera.id=%s, file=%s, rtsp_url=%s\n", _camera.id.c_str(), _camera.record_file_path.value().c_str(), _camera.rtsp_url.value().c_str());
-    fflush(stdout);
-
     _source.play();
 }
 
@@ -348,17 +344,7 @@ bool r_recording_context::dead() const
     auto video_dead = ((now - _last_v_time) > seconds(20));
     bool is_dead = (_has_audio)?((now - _last_a_time) > seconds(20))||video_dead:video_dead;
     if(_die)
-    {
-        printf("FORCE DIE\n");
         is_dead = true;
-    }
-
-    if(is_dead)
-    {
-        R_LOG_INFO("found dead stream: camera.id=%s now=%s last_v_time=%s last_a_time=%s", _camera.id.c_str(), r_time_utils::tp_to_iso_8601(now,false).c_str(), r_time_utils::tp_to_iso_8601(_last_v_time,false).c_str(), r_time_utils::tp_to_iso_8601(_last_a_time,false).c_str());
-        printf("found dead stream: camera.id=%s now=%s last_v_time=%s last_a_time=%s\n", _camera.id.c_str(), r_time_utils::tp_to_iso_8601(now,false).c_str(), r_time_utils::tp_to_iso_8601(_last_v_time,false).c_str(), r_time_utils::tp_to_iso_8601(_last_a_time,false).c_str());
-        fflush(stdout);
-    }
 
     return is_dead;
 }
@@ -766,6 +752,7 @@ void r_recording_context::_playback_restream_media_configure(GstRTSPMediaFactory
 
     tie(prs->friendly_name, prs->start_time, prs->end_time) =
         _get_playback_url_parts();
+
     prs->query_start = prs->start_time;
     prs->query_end = prs->start_time + seconds(5);
     prs->camera_id = _camera.id;


### PR DESCRIPTION
Cameras with spaces in their friendly names (e.g., 'Raccoon Cam') failed to play recorded video. The playback URL converts spaces to underscores (/Raccoon_Cam_2024-12-16T10:00:00.000Z_...) but the lookup compared against the original name with spaces, so no match was found. Changes:
- r_stream_keeper.cpp: Normalize camera friendly names (spaces → underscores) before comparing to URL-extracted names
- add try/catch around RTSP OPTIONS callback to catch and log exceptions instead of letting them propagate into GStreamer's C code
- pipeline_state.h/.cpp: Add 15-second grace period before dead stream detection (playback streams need more startup time than live)