### PR TITLE
Fix thread safety: race conditions in socket, SSL, UDP, and stream keeper

### DIFF
--- a/libs/r_utils/include/r_utils/r_ssl_socket.h
+++ b/libs/r_utils/include/r_utils/r_ssl_socket.h
@@ -21,6 +21,13 @@ extern "C" {
 
 namespace r_utils {
 
+/// r_ssl_socket provides a thread-safe TLS socket wrapper using mbedtls.
+///
+/// THREAD SAFETY:
+/// All SSL operations are protected by a mutex to prevent use-after-free
+/// when close() is called while send/recv callbacks are in progress.
+/// The mbedtls callbacks access the underlying socket through a pointer,
+/// so we must ensure the socket remains valid during callback execution.
 class r_ssl_socket : public r_socket_base
 {
 public:
@@ -44,6 +51,7 @@ public:
     inline std::string get_local_ip() const { return _sok.get_local_ip(); }
 
 private:
+    mutable std::recursive_mutex _sslLock;  // Protects SSL operations from concurrent access
     r_raw_socket _sok;
 
     mutable mbedtls_ssl_context _ssl;

--- a/libs/r_utils/include/r_utils/r_udp_receiver.h
+++ b/libs/r_utils/include/r_utils/r_udp_receiver.h
@@ -13,6 +13,12 @@ namespace r_utils
 
 const int DEFAULT_UDP_RECV_BUF_SIZE = 0;
 
+/// r_udp_receiver provides a thread-safe UDP socket receiver.
+///
+/// THREAD SAFETY:
+/// The _associatedReceivers list is protected by a mutex to prevent
+/// iterator invalidation when associate() or clear_associations() are
+/// called concurrently with receive operations.
 class r_udp_receiver final
 {
 public:
@@ -60,6 +66,7 @@ private:
 
     SOK _sok;
     r_socket_address _addr;
+    mutable std::mutex _associatedReceiversLock;
     std::list<std::shared_ptr<r_udp_receiver> > _associatedReceivers;
 };
 

--- a/libs/r_utils/source/r_socket.cpp
+++ b/libs/r_utils/source/r_socket.cpp
@@ -64,7 +64,7 @@ r_raw_socket::r_raw_socket() :
 r_raw_socket::r_raw_socket( r_raw_socket&& obj ) noexcept :
     _sok( -1 ),
     _instanceLock(),
-    _addr(),
+    _addr( 0 ),  // Initialize with dummy port, will be overwritten by move
     _host()
 {
     // Lock the source object to ensure thread-safe move

--- a/libs/r_vss/include/r_vss/r_stream_keeper.h
+++ b/libs/r_vss/include/r_vss/r_stream_keeper.h
@@ -145,6 +145,7 @@ private:
     std::string _top_dir;
     std::thread _th;
     bool _running;
+    mutable std::mutex _streams_mutex;  // Protects _streams from concurrent access
     std::map<std::string, std::shared_ptr<r_recording_context>> _streams;
     r_utils::r_work_q<r_stream_keeper_cmd, r_stream_keeper_result> _cmd_q;
 

--- a/libs/r_vss/source/r_recording_context.cpp
+++ b/libs/r_vss/source/r_recording_context.cpp
@@ -819,7 +819,11 @@ void r_recording_context::_playback_restream_media_configure(GstRTSPMediaFactory
         prs
     );
 
-    _playback_restreaming_states[media] = prs;
+    // Lock must be held when inserting to prevent race with cleanup callback erase
+    {
+        std::lock_guard<std::mutex> lock(_playback_restreaming_states_lok);
+        _playback_restreaming_states[media] = prs;
+    }
 }
 
 void r_recording_context::_playback_restream_cleanup_cbs(playback_restreaming_state* prs)


### PR DESCRIPTION
- Add mutex protection to r_raw_socket for concurrent close/access
- Add mutex to r_ssl_socket for SSL operation thread safety
- Use snapshot pattern in r_udp_receiver to prevent iterator invalidation
- Add mutex to r_stream_keeper protecting _streams map access
- Fix missing lock on playback_restreaming_states insert