### PR TITLE
macOS: fix app bundle packaging and launch vision from build dir

### DIFF
--- a/apps/revere/CMakeLists.txt
+++ b/apps/revere/CMakeLists.txt
@@ -33,10 +33,11 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(traypp)
 
-# On macOS, patch traypp to not use template mode so the color icon is preserved
+# On macOS, patch traypp: use color icon and show app in Cmd-Tab / Dock
 if(APPLE)
     file(READ ${traypp_SOURCE_DIR}/tray/src/core/macos/tray.mm TRAY_MM_CONTENT)
     string(REPLACE "[nsIcon setTemplate:YES]" "[nsIcon setTemplate:NO]" TRAY_MM_CONTENT "${TRAY_MM_CONTENT}")
+    string(REPLACE "NSApplicationActivationPolicyAccessory" "NSApplicationActivationPolicyRegular" TRAY_MM_CONTENT "${TRAY_MM_CONTENT}")
     file(WRITE ${traypp_SOURCE_DIR}/tray/src/core/macos/tray.mm "${TRAY_MM_CONTENT}")
 endif()
 
@@ -181,5 +182,24 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     add_custom_command(TARGET revere POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/R.png $<TARGET_BUNDLE_DIR:revere>/Contents/MacOS/R.png
     )
+
+    # Copy system plugins into the app bundle
+    add_custom_command(TARGET revere POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_BUNDLE_DIR:revere>/Contents/MacOS/system_plugins
+        COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_BINARY_DIR}/system_plugins $<TARGET_BUNDLE_DIR:revere>/Contents/MacOS/system_plugins
+    )
+
+    # Copy motion plugins and model files into the app bundle
+    add_custom_command(TARGET revere POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_BUNDLE_DIR:revere>/Contents/MacOS/motion_plugins
+        COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_BINARY_DIR}/motion_plugins $<TARGET_BUNDLE_DIR:revere>/Contents/MacOS/motion_plugins
+    )
+    if(NCNN_AVAILABLE)
+        add_custom_command(TARGET revere POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_BUNDLE_DIR:revere>/Contents/MacOS/models/yolov8_person
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_SOURCE_DIR}/libs/r_vss/motion_plugins/yolov8_person_plugin/model/yolov8n.param $<TARGET_BUNDLE_DIR:revere>/Contents/MacOS/models/yolov8_person/
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_SOURCE_DIR}/libs/r_vss/motion_plugins/yolov8_person_plugin/model/yolov8n.bin $<TARGET_BUNDLE_DIR:revere>/Contents/MacOS/models/yolov8_person/
+        )
+    endif()
 endif()
 

--- a/apps/revere/source/main.cpp
+++ b/apps/revere/source/main.cpp
@@ -1235,7 +1235,15 @@ int main(int argc, char** argv)
     vision_cmd = "vision.exe";
 #elif defined(IS_MACOS)
     // On macOS, use 'open' command to launch the app bundle
-    vision_cmd = "open -n /Applications/Vision.app";
+    // Look for vision.app next to revere.app first, then fall back to /Applications
+    {
+        auto exe_dir = r_fs::working_directory();
+        auto local_vision = exe_dir + "/../../../vision.app";
+        if(r_fs::is_dir(local_vision))
+            vision_cmd = "open -n " + local_vision;
+        else
+            vision_cmd = "open -n /Applications/Vision.app";
+    }
 #endif
 
     r_process vision_process(vision_cmd, true); // Use detached process

--- a/apps/vision/CMakeLists.txt
+++ b/apps/vision/CMakeLists.txt
@@ -106,7 +106,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     # target_sources(vision PRIVATE ${APP_ICON})
 
     # Copy shared libraries into the app bundle so it can find them at runtime
-    set(VISION_LIBS r_utils r_ui_utils r_av r_pipeline r_storage r_motion r_onvif r_http r_db r_vss)
+    set(VISION_LIBS r_utils r_ui_utils r_av r_pipeline r_storage r_motion r_onvif r_http r_db r_vss r_disco r_fakey)
     foreach(LIB ${VISION_LIBS})
         add_custom_command(TARGET vision POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_BUNDLE_DIR:vision>/Contents/lib


### PR DESCRIPTION
## Summary
- Fix macOS app bundle packaging in CMake build
- Launch vision from the build directory
- Updates to `apps/revere/CMakeLists.txt`, `apps/revere/source/main.cpp`, and `apps/vision/CMakeLists.txt`