### PR TITLE
Add optional status reporting API for system plugins

### DIFF
--- a/libs/r_vss/include/r_vss/r_stream_keeper.h
+++ b/libs/r_vss/include/r_vss/r_stream_keeper.h
@@ -147,6 +147,8 @@ public:
     R_API std::vector<std::string> get_loaded_system_plugins() const;
     R_API bool is_system_plugin_enabled(const std::string& plugin_name) const;
     R_API void set_system_plugin_enabled(const std::string& plugin_name, bool enabled);
+    R_API std::string get_system_plugin_status(const std::string& plugin_name) const;
+    R_API std::string get_system_plugin_status_message(const std::string& plugin_name) const;
 
     // Live restreaming state management (owned by r_stream_keeper for safe cleanup)
     R_API void add_live_restreaming_state(GstRTSPMedia* media, std::shared_ptr<live_restreaming_state> lrs);

--- a/libs/r_vss/include/r_vss/r_system_plugin.h
+++ b/libs/r_vss/include/r_vss/r_system_plugin.h
@@ -46,6 +46,16 @@ R_API bool system_plugin_enabled(r_system_plugin_handle plugin);
 // enabled: true to enable, false to disable
 R_API void system_plugin_set_enabled(r_system_plugin_handle plugin, bool enabled);
 
+// Optional: Get the plugin's current status string
+// Returns: A status string (e.g., "disabled", "authenticating", "connected", "not_connected")
+// The returned string must remain valid until the next call to this function
+// Plugins that don't implement this export will have no status displayed
+R_API const char* system_plugin_get_status(r_system_plugin_handle plugin);
+
+// Optional: Get additional status detail (e.g., user code, URL during auth)
+// Returns: A detail string, empty if no details available
+R_API const char* system_plugin_get_status_message(r_system_plugin_handle plugin);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libs/r_vss/include/r_vss/r_system_plugin_host.h
+++ b/libs/r_vss/include/r_vss/r_system_plugin_host.h
@@ -36,6 +36,12 @@ public:
     // Enable or disable a plugin by name
     R_API void set_plugin_enabled(const std::string& plugin_name, bool enabled);
 
+    // Get plugin status string (returns empty string if plugin doesn't support status)
+    R_API std::string get_plugin_status(const std::string& plugin_name) const;
+
+    // Get plugin status message (returns empty string if plugin doesn't support it)
+    R_API std::string get_plugin_status_message(const std::string& plugin_name) const;
+
 private:
     struct plugin_info
     {
@@ -46,6 +52,8 @@ private:
         void (*destroy_func)(r_system_plugin_handle);
         bool (*enabled_func)(r_system_plugin_handle);
         void (*set_enabled_func)(r_system_plugin_handle, bool);
+        const char* (*status_func)(r_system_plugin_handle); // Optional - nullptr if not supported
+        const char* (*status_message_func)(r_system_plugin_handle); // Optional - nullptr if not supported
         std::string name;
         std::string guid;
     };

--- a/libs/r_vss/source/r_stream_keeper.cpp
+++ b/libs/r_vss/source/r_stream_keeper.cpp
@@ -443,6 +443,16 @@ void r_stream_keeper::set_system_plugin_enabled(const std::string& plugin_name, 
     _system_plugin_host.set_plugin_enabled(plugin_name, enabled);
 }
 
+std::string r_stream_keeper::get_system_plugin_status(const std::string& plugin_name) const
+{
+    return _system_plugin_host.get_plugin_status(plugin_name);
+}
+
+std::string r_stream_keeper::get_system_plugin_status_message(const std::string& plugin_name) const
+{
+    return _system_plugin_host.get_plugin_status_message(plugin_name);
+}
+
 void r_stream_keeper::bounce(const std::string& camera_id)
 {
     r_stream_keeper_cmd cmd;


### PR DESCRIPTION
## Summary
- Extends the system plugin interface with optional `get_status` / `get_status_message` exports
- Plugins can report connection state (connected, authenticating, not_connected, disabled)
- UI displays a colored dot indicator per plugin with status label
- Supports device auth flows with Copy Code, Copy URL, and Open in Browser buttons