### PR TITLE
Add JSON-based plugin status reporting

### DIFF
--- a/apps/revere/source/main.cpp
+++ b/apps/revere/source/main.cpp
@@ -1731,34 +1731,6 @@ int main(int argc, char** argv)
                                 }
 
                                 // Show status indicator if plugin supports it
-<<<<<<< Updated upstream
-                                auto status = streamKeeper.get_system_plugin_status(plugin_name);
-                                if (!status.empty())
-                                {
-                                    ImU32 dot_color;
-                                    const char* status_label;
-
-                                    if (status == "connected")
-                                    {
-                                        dot_color = IM_COL32(50, 200, 50, 255);
-                                        status_label = "Connected";
-                                    }
-                                    else if (status == "authenticating")
-                                    {
-                                        dot_color = IM_COL32(220, 180, 50, 255);
-                                        status_label = "Authenticating...";
-                                    }
-                                    else if (status == "not_connected")
-                                    {
-                                        dot_color = IM_COL32(200, 50, 50, 255);
-                                        status_label = "Not Connected";
-                                    }
-                                    else
-                                    {
-                                        dot_color = IM_COL32(100, 100, 100, 255);
-                                        status_label = "Disabled";
-                                    }
-=======
                                 auto status_json = streamKeeper.get_system_plugin_status(plugin_name);
                                 if (!status_json.empty())
                                 {
@@ -1771,7 +1743,6 @@ int main(int argc, char** argv)
                                     int g = color_arr.size() > 1 ? color_arr[1] : 100;
                                     int b = color_arr.size() > 2 ? color_arr[2] : 100;
                                     ImU32 dot_color = IM_COL32(r, g, b, 255);
->>>>>>> Stashed changes
 
                                     ImGui::Indent(28.0f);
                                     auto cursor = ImGui::GetCursorScreenPos();
@@ -1779,64 +1750,6 @@ int main(int argc, char** argv)
                                     ImVec2 dot_center(cursor.x + dot_radius, cursor.y + ImGui::GetTextLineHeight() * 0.5f);
                                     ImGui::GetWindowDrawList()->AddCircleFilled(dot_center, dot_radius, dot_color);
                                     ImGui::SetCursorPosX(ImGui::GetCursorPosX() + dot_radius * 2.0f + 6.0f);
-<<<<<<< Updated upstream
-                                    ImGui::TextColored(ImVec4(0.7f, 0.7f, 0.7f, 1.0f), "%s", status_label);
-
-                                    // Show status message details (e.g., user code + URL during auth)
-                                    auto status_message = streamKeeper.get_system_plugin_status_message(plugin_name);
-                                    if (!status_message.empty())
-                                    {
-                                        // Parse "Code: XXXX-XXXX\nhttps://..." into separate lines
-                                        auto newline_pos = status_message.find('\n');
-                                        if (newline_pos != std::string::npos)
-                                        {
-                                            auto code_line = status_message.substr(0, newline_pos);
-                                            auto url_line = status_message.substr(newline_pos + 1);
-
-                                            // Show user code prominently
-                                            ImGui::TextColored(ImVec4(1.0f, 1.0f, 0.6f, 1.0f), "%s", code_line.c_str());
-
-                                            // Copy code button
-                                            ImGui::SameLine();
-                                            // Extract just the code value after "Code: "
-                                            auto code_value = code_line.substr(code_line.find(": ") != std::string::npos ? code_line.find(": ") + 2 : 0);
-                                            if (ImGui::SmallButton("Copy Code"))
-                                                ImGui::SetClipboardText(code_value.c_str());
-
-                                            // Show URL with wrapping
-                                            ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + ImGui::GetContentRegionAvail().x);
-                                            ImGui::TextColored(ImVec4(0.5f, 0.5f, 0.5f, 1.0f), "%s", url_line.c_str());
-                                            ImGui::PopTextWrapPos();
-
-                                            // Open in browser button
-                                            if (ImGui::SmallButton("Open in Browser"))
-                                            {
-                                                std::string open_cmd;
-#if defined(IS_MACOS) || defined(__APPLE__)
-                                                open_cmd = "open \"" + url_line + "\"";
-#elif defined(IS_LINUX)
-                                                open_cmd = "xdg-open \"" + url_line + "\"";
-#elif defined(IS_WINDOWS)
-                                                open_cmd = "start \"\" \"" + url_line + "\"";
-#endif
-                                                if (!open_cmd.empty())
-                                                    system(open_cmd.c_str());
-                                            }
-                                            ImGui::SameLine();
-                                            if (ImGui::SmallButton("Copy URL"))
-                                                ImGui::SetClipboardText(url_line.c_str());
-                                        }
-                                        else
-                                        {
-                                            ImGui::TextWrapped("%s", status_message.c_str());
-                                        }
-                                    }
-
-                                    ImGui::Unindent(28.0f);
-                                }
-
-                                ImGui::Spacing();
-=======
                                     ImGui::TextColored(ImVec4(0.7f, 0.7f, 0.7f, 1.0f), "%s", label.c_str());
 
                                     // Show status message details (parsed from JSON)
@@ -1902,7 +1815,6 @@ int main(int argc, char** argv)
                                     }
                                     catch (...) {}
                                 }
->>>>>>> Stashed changes
                             }
                         }
 

--- a/apps/revere/source/main.cpp
+++ b/apps/revere/source/main.cpp
@@ -43,6 +43,7 @@
 #include "r_av/r_video_decoder.h"
 #include "r_ui_utils/stb_image.h"
 #include "r_ui_utils/font_catalog.h"
+#include "r_utils/3rdparty/json/json.h"
 #include "r_ui_utils/texture_loader.h"
 #include "r_ui_utils/wizard.h"
 
@@ -1730,6 +1731,7 @@ int main(int argc, char** argv)
                                 }
 
                                 // Show status indicator if plugin supports it
+<<<<<<< Updated upstream
                                 auto status = streamKeeper.get_system_plugin_status(plugin_name);
                                 if (!status.empty())
                                 {
@@ -1756,6 +1758,20 @@ int main(int argc, char** argv)
                                         dot_color = IM_COL32(100, 100, 100, 255);
                                         status_label = "Disabled";
                                     }
+=======
+                                auto status_json = streamKeeper.get_system_plugin_status(plugin_name);
+                                if (!status_json.empty())
+                                {
+                                    try
+                                    {
+                                    auto sj = nlohmann::json::parse(status_json);
+                                    auto label = sj.value("label", std::string("Unknown"));
+                                    auto color_arr = sj.value("color", std::vector<int>{100, 100, 100});
+                                    int r = color_arr.size() > 0 ? color_arr[0] : 100;
+                                    int g = color_arr.size() > 1 ? color_arr[1] : 100;
+                                    int b = color_arr.size() > 2 ? color_arr[2] : 100;
+                                    ImU32 dot_color = IM_COL32(r, g, b, 255);
+>>>>>>> Stashed changes
 
                                     ImGui::Indent(28.0f);
                                     auto cursor = ImGui::GetCursorScreenPos();
@@ -1763,6 +1779,7 @@ int main(int argc, char** argv)
                                     ImVec2 dot_center(cursor.x + dot_radius, cursor.y + ImGui::GetTextLineHeight() * 0.5f);
                                     ImGui::GetWindowDrawList()->AddCircleFilled(dot_center, dot_radius, dot_color);
                                     ImGui::SetCursorPosX(ImGui::GetCursorPosX() + dot_radius * 2.0f + 6.0f);
+<<<<<<< Updated upstream
                                     ImGui::TextColored(ImVec4(0.7f, 0.7f, 0.7f, 1.0f), "%s", status_label);
 
                                     // Show status message details (e.g., user code + URL during auth)
@@ -1819,6 +1836,73 @@ int main(int argc, char** argv)
                                 }
 
                                 ImGui::Spacing();
+=======
+                                    ImGui::TextColored(ImVec4(0.7f, 0.7f, 0.7f, 1.0f), "%s", label.c_str());
+
+                                    // Show status message details (parsed from JSON)
+                                    auto status_message = streamKeeper.get_system_plugin_status_message(plugin_name);
+                                    if (!status_message.empty())
+                                    {
+                                        try
+                                        {
+                                            auto j = nlohmann::json::parse(status_message);
+                                            if (j.contains("lines") && j["lines"].is_array())
+                                            {
+                                                for (const auto& line : j["lines"])
+                                                {
+                                                    auto text = line.value("text", std::string());
+                                                    if (text.empty())
+                                                        continue;
+
+                                                    bool has_copy = line.contains("copy");
+                                                    bool has_url = line.contains("url");
+
+                                                    if (has_url)
+                                                    {
+                                                        ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + ImGui::GetContentRegionAvail().x);
+                                                        ImGui::TextColored(ImVec4(0.5f, 0.5f, 0.5f, 1.0f), "%s", text.c_str());
+                                                        ImGui::PopTextWrapPos();
+
+                                                        auto url_val = line["url"].get<std::string>();
+                                                        ImGui::SameLine();
+                                                        if (ImGui::SmallButton(("Open##" + text).c_str()))
+                                                        {
+#if defined(IS_MACOS) || defined(__APPLE__)
+                                                            std::string open_cmd = "open \"" + url_val + "\"";
+#elif defined(IS_LINUX)
+                                                            std::string open_cmd = "xdg-open \"" + url_val + "\"";
+#elif defined(IS_WINDOWS)
+                                                            std::string open_cmd = "start \"\" \"" + url_val + "\"";
+#endif
+                                                            system(open_cmd.c_str());
+                                                        }
+                                                        ImGui::SameLine();
+                                                        if (ImGui::SmallButton(("Copy URL##" + text).c_str()))
+                                                            ImGui::SetClipboardText(url_val.c_str());
+                                                    }
+                                                    else
+                                                    {
+                                                        ImGui::TextColored(ImVec4(1.0f, 1.0f, 0.6f, 1.0f), "%s", text.c_str());
+
+                                                        if (has_copy)
+                                                        {
+                                                            auto copy_val = line["copy"].get<std::string>();
+                                                            ImGui::SameLine();
+                                                            if (ImGui::SmallButton(("Copy##" + text).c_str()))
+                                                                ImGui::SetClipboardText(copy_val.c_str());
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        catch (...) {}
+                                    }
+
+                                    ImGui::Unindent(28.0f);
+                                    }
+                                    catch (...) {}
+                                }
+>>>>>>> Stashed changes
                             }
                         }
 

--- a/libs/r_vss/include/r_vss/r_system_plugin_host.h
+++ b/libs/r_vss/include/r_vss/r_system_plugin_host.h
@@ -36,10 +36,17 @@ public:
     // Enable or disable a plugin by name
     R_API void set_plugin_enabled(const std::string& plugin_name, bool enabled);
 
+<<<<<<< Updated upstream
     // Get plugin status string (returns empty string if plugin doesn't support status)
     R_API std::string get_plugin_status(const std::string& plugin_name) const;
 
     // Get plugin status message (returns empty string if plugin doesn't support it)
+=======
+    // Get a plugin's current status string (empty if plugin doesn't support status reporting)
+    R_API std::string get_plugin_status(const std::string& plugin_name) const;
+
+    // Get a plugin's current status message JSON (empty if no message)
+>>>>>>> Stashed changes
     R_API std::string get_plugin_status_message(const std::string& plugin_name) const;
 
 private:
@@ -52,8 +59,13 @@ private:
         void (*destroy_func)(r_system_plugin_handle);
         bool (*enabled_func)(r_system_plugin_handle);
         void (*set_enabled_func)(r_system_plugin_handle, bool);
+<<<<<<< Updated upstream
         const char* (*status_func)(r_system_plugin_handle); // Optional - nullptr if not supported
         const char* (*status_message_func)(r_system_plugin_handle); // Optional - nullptr if not supported
+=======
+        const char* (*status_func)(r_system_plugin_handle);          // Optional - nullptr if not supported
+        const char* (*status_message_func)(r_system_plugin_handle);  // Optional - nullptr if not supported
+>>>>>>> Stashed changes
         std::string name;
         std::string guid;
     };

--- a/libs/r_vss/include/r_vss/r_system_plugin_host.h
+++ b/libs/r_vss/include/r_vss/r_system_plugin_host.h
@@ -36,17 +36,11 @@ public:
     // Enable or disable a plugin by name
     R_API void set_plugin_enabled(const std::string& plugin_name, bool enabled);
 
-<<<<<<< Updated upstream
-    // Get plugin status string (returns empty string if plugin doesn't support status)
-    R_API std::string get_plugin_status(const std::string& plugin_name) const;
-
-    // Get plugin status message (returns empty string if plugin doesn't support it)
-=======
-    // Get a plugin's current status string (empty if plugin doesn't support status reporting)
+    // Get a plugin's current status JSON (empty if plugin doesn't support status reporting)
     R_API std::string get_plugin_status(const std::string& plugin_name) const;
 
     // Get a plugin's current status message JSON (empty if no message)
->>>>>>> Stashed changes
+
     R_API std::string get_plugin_status_message(const std::string& plugin_name) const;
 
 private:
@@ -59,13 +53,8 @@ private:
         void (*destroy_func)(r_system_plugin_handle);
         bool (*enabled_func)(r_system_plugin_handle);
         void (*set_enabled_func)(r_system_plugin_handle, bool);
-<<<<<<< Updated upstream
-        const char* (*status_func)(r_system_plugin_handle); // Optional - nullptr if not supported
-        const char* (*status_message_func)(r_system_plugin_handle); // Optional - nullptr if not supported
-=======
         const char* (*status_func)(r_system_plugin_handle);          // Optional - nullptr if not supported
         const char* (*status_message_func)(r_system_plugin_handle);  // Optional - nullptr if not supported
->>>>>>> Stashed changes
         std::string name;
         std::string guid;
     };

--- a/libs/r_vss/source/r_system_plugin_host.cpp
+++ b/libs/r_vss/source/r_system_plugin_host.cpp
@@ -94,22 +94,6 @@ r_system_plugin_host::r_system_plugin_host(const std::string& top_dir)
                                 // Optional: resolve status functions (nullptr if not supported)
                                 system_plugin_get_status_func status_func = nullptr;
                                 system_plugin_get_status_message_func status_message_func = nullptr;
-<<<<<<< Updated upstream
-                                try
-                                {
-                                    void* status_symbol = lib->resolve_symbol("system_plugin_get_status");
-                                    if (status_symbol)
-                                        status_func = reinterpret_cast<system_plugin_get_status_func>(status_symbol);
-                                }
-                                catch (...) {}
-                                try
-                                {
-                                    void* msg_symbol = lib->resolve_symbol("system_plugin_get_status_message");
-                                    if (msg_symbol)
-                                        status_message_func = reinterpret_cast<system_plugin_get_status_message_func>(msg_symbol);
-                                }
-                                catch (...) {}
-=======
                                 try {
                                     void* status_symbol = lib->resolve_symbol("system_plugin_get_status");
                                     if (status_symbol)
@@ -120,7 +104,6 @@ r_system_plugin_host::r_system_plugin_host(const std::string& top_dir)
                                     if (msg_symbol)
                                         status_message_func = reinterpret_cast<system_plugin_get_status_message_func>(msg_symbol);
                                 } catch (...) {}
->>>>>>> Stashed changes
 
                                 // Get the plugin GUID and check for duplicates
                                 const char* guid_cstr = guid_func();

--- a/libs/r_vss/source/r_system_plugin_host.cpp
+++ b/libs/r_vss/source/r_system_plugin_host.cpp
@@ -94,6 +94,7 @@ r_system_plugin_host::r_system_plugin_host(const std::string& top_dir)
                                 // Optional: resolve status functions (nullptr if not supported)
                                 system_plugin_get_status_func status_func = nullptr;
                                 system_plugin_get_status_message_func status_message_func = nullptr;
+<<<<<<< Updated upstream
                                 try
                                 {
                                     void* status_symbol = lib->resolve_symbol("system_plugin_get_status");
@@ -108,6 +109,18 @@ r_system_plugin_host::r_system_plugin_host(const std::string& top_dir)
                                         status_message_func = reinterpret_cast<system_plugin_get_status_message_func>(msg_symbol);
                                 }
                                 catch (...) {}
+=======
+                                try {
+                                    void* status_symbol = lib->resolve_symbol("system_plugin_get_status");
+                                    if (status_symbol)
+                                        status_func = reinterpret_cast<system_plugin_get_status_func>(status_symbol);
+                                } catch (...) {}
+                                try {
+                                    void* msg_symbol = lib->resolve_symbol("system_plugin_get_status_message");
+                                    if (msg_symbol)
+                                        status_message_func = reinterpret_cast<system_plugin_get_status_message_func>(msg_symbol);
+                                } catch (...) {}
+>>>>>>> Stashed changes
 
                                 // Get the plugin GUID and check for duplicates
                                 const char* guid_cstr = guid_func();


### PR DESCRIPTION
## Summary
- Add optional `system_plugin_get_status` and `system_plugin_get_status_message` symbol resolution at plugin load time
- Status returns JSON with `label` and `color` fields, giving plugins full control over the dot indicator appearance
- Status message returns JSON with a `lines` array where each line can have `text`, `copy`, and `url` fields for flexible UI rendering
- UI parses both JSON payloads and renders colored dot, label, and interactive buttons (Copy, Open in Browser)