### PR TITLE
Add stream health indicator dots to camera sidebar

### DIFF
--- a/apps/revere/include/imgui_ui.h
+++ b/apps/revere/include/imgui_ui.h
@@ -295,6 +295,13 @@ void rtsp_credentials_modal(
     }
 }
 
+enum class stream_health
+{
+    unknown,    // no status data available
+    healthy,    // receiving video frames
+    error       // not receiving video frames
+};
+
 struct sidebar_list_ui_item
 {
     std::string label;
@@ -302,6 +309,7 @@ struct sidebar_list_ui_item
     std::string camera_id;
     std::string kbps;
     std::string retention;
+    stream_health health {stream_health::unknown};
 };
 
 template<typename BUTTON_CLICK_CB, typename ITEM_CLICK_CB, typename FORGET_BUTTON_CLICK_CB, typename PROPERTIES_CLICK_CB>
@@ -350,6 +358,14 @@ void sidebar_list(
     };
     std::vector<TextRenderInfo> text_to_render;
     text_to_render.reserve(labels.size() * 2);
+
+    // Store health indicator positions for drawing after text
+    struct HealthDotInfo {
+        ImVec2 position;
+        stream_health health;
+    };
+    std::vector<HealthDotInfo> health_dots;
+    health_dots.reserve(labels.size());
 
     // selectable list - first pass: interactive elements
     for(int i = 0; i < (int)labels.size(); ++i)
@@ -455,6 +471,10 @@ void sidebar_list(
         text_to_render.push_back({ImVec2(pos.x+10, pos.y+5), labels[i].label, true});
         text_to_render.push_back({ImVec2(pos.x+10, pos.y+28), labels[i].sub_label, false});
 
+        // Store health indicator position (right-aligned in the selectable area)
+        if(labels[i].health != stream_health::unknown)
+            health_dots.push_back({ImVec2(pos.x + width - 30, pos.y + 12), labels[i].health});
+
         pos.y += 110;
 
         ImGui::PopID();
@@ -482,6 +502,19 @@ void sidebar_list(
         }
     }
     ImGui::PopFont();
+
+    // Third pass: draw health indicator dots
+    ImDrawList* health_draw_list = ImGui::GetWindowDrawList();
+    for(const auto& dot : health_dots)
+    {
+        auto screen_pos = ImGui::GetWindowPos();
+        ImVec2 center(screen_pos.x + dot.position.x, screen_pos.y + dot.position.y);
+        float radius = 5.0f;
+        ImU32 color = (dot.health == stream_health::healthy) ?
+            IM_COL32(0, 200, 0, 255) :   // green
+            IM_COL32(200, 0, 0, 255);     // red
+        health_draw_list->AddCircleFilled(center, radius, color);
+    }
 }
 
 template<typename OK_CB, typename CANCEL_CB>

--- a/apps/revere/source/main.cpp
+++ b/apps/revere/source/main.cpp
@@ -195,18 +195,20 @@ void _update_list_ui(revere_ui_state& ui_state, r_disco::r_devices& devices, r_v
         item.sub_label = c.second.ipv4.value();
         item.camera_id = c.first;
 
-        // Populate kbps and retention if stream status is available
+        // Populate kbps, retention, and health if stream status is available
         if(status_by_id.find(c.first) != status_by_id.end())
         {
             auto& status = status_by_id[c.first];
             item.kbps = r_string_utils::format("%ld kbps", (status.bytes_per_second*8)/1024);
             auto retention_days = ((double)streamKeeper.get_retention_hours(status.camera.id).count()) / 24.0;
             item.retention = r_string_utils::format("%.2f days", retention_days);
+            item.health = status.receiving_video ? revere::stream_health::healthy : revere::stream_health::error;
         }
         else
         {
             item.kbps = "N/A";
             item.retention = "N/A";
+            item.health = revere::stream_health::unknown;
         }
 
         ui_state.recording_items.push_back(item);

--- a/libs/r_vss/include/r_vss/r_recording_context.h
+++ b/libs/r_vss/include/r_vss/r_recording_context.h
@@ -132,6 +132,8 @@ public:
 
     R_API int32_t bytes_per_second() const;
 
+    R_API bool receiving_video() const;
+
     R_API r_storage::r_md_storage_file& metadata_storage();
 
     R_API void write_metadata(const std::string& stream_tag, const std::string& json_data, int64_t timestamp_ms);

--- a/libs/r_vss/include/r_vss/r_stream_keeper.h
+++ b/libs/r_vss/include/r_vss/r_stream_keeper.h
@@ -82,6 +82,7 @@ struct r_stream_status
 {
     r_disco::r_camera camera;
     uint32_t bytes_per_second;
+    bool receiving_video {false};
     r_overflow_type overflow_flags {r_overflow_type::none};
     size_t dropped_frames {0};  // Total frames dropped since last check
 };

--- a/libs/r_vss/source/r_recording_context.cpp
+++ b/libs/r_vss/source/r_recording_context.cpp
@@ -368,6 +368,11 @@ r_recording_context::~r_recording_context() noexcept
         _maybe_audio_storage_write_context.clear();
 }
 
+bool r_recording_context::receiving_video() const
+{
+    return _got_first_video_sample;
+}
+
 bool r_recording_context::dead() const
 {
     auto now = system_clock::now();

--- a/libs/r_vss/source/r_stream_keeper.cpp
+++ b/libs/r_vss/source/r_stream_keeper.cpp
@@ -303,10 +303,13 @@ std::string r_stream_keeper::add_restream_mount(const std::map<std::string, r_pi
 
 void r_stream_keeper::remove_restream_mount(const string& mount_path)
 {
+    if(mount_path.empty() || mount_path[0] != '/')
+        return;
+
     // Safety check: return early if objects are null or invalid
     if(!_mounts || !GST_IS_RTSP_MOUNT_POINTS(_mounts))
         return;
-    
+
     if(!_server || !GST_IS_RTSP_SERVER(_server))
         return;
 
@@ -661,6 +664,7 @@ vector<r_stream_status> r_stream_keeper::_fetch_stream_status() const
             r_stream_status s;
             s.camera = c.second->camera();
             s.bytes_per_second = c.second->bytes_per_second();
+            s.receiving_video = c.second->receiving_video();
             return s;
         }
     );


### PR DESCRIPTION
## Summary
- Adds green/red health indicator dots next to each camera in the sidebar showing whether video frames are being received
- Exposes `receiving_video()` from `r_recording_context` and propagates through `r_stream_status`
- Fixes restream mount removal safety check for empty paths