### PR TITLE
r_websocket: bump read_exact timeout from 30s → 120s

### DIFF
--- a/libs/r_http/source/r_websocket.cpp
+++ b/libs/r_http/source/r_websocket.cpp
@@ -176,8 +176,24 @@ void r_websocket::read_exact(r_utils::r_socket_base& sock, uint8_t* buffer, size
 {
     size_t total_read = 0;
     while (total_read < length) {
-        // Use r_networking::r_recv() which properly handles SSL WANT_READ/WANT_WRITE states
-        uint64_t timeout_ms = 30000;  // 30 second timeout for WebSocket reads
+        // Use r_networking::r_recv() which properly handles SSL WANT_READ/WANT_WRITE states.
+        //
+        // Timeout sized for idle WebSocket connections: the keepalive thread
+        // sends an RFC 6455 ping every 30s, the server pongs back, so we
+        // expect inbound traffic at least every 30s on a healthy connection.
+        // 120s gives 4x cushion — enough to absorb sleep/wake transitions
+        // and a couple of dropped pongs without falsely declaring the
+        // socket dead and forcing a reconnect.
+        //
+        // True deadness is still detected promptly via:
+        //   * recv returning 0 (TCP FIN / clean close) → throw below
+        //   * keepalive_loop's send_ping failing → r_websocket_client
+        //     flips _connected = false
+        //
+        // The 30s value previously here meant a single quiet idle period
+        // (e.g., laptop sleep, brief NAT hiccup) was enough to force a
+        // full reconnect cycle.
+        uint64_t timeout_ms = 120000;
         int bytes_read = r_networking::r_recv(sock, buffer + total_read, length - total_read, timeout_ms);
 
         if (bytes_read <= 0)


### PR DESCRIPTION
After the WS heartbeat / Hibernating WebSockets migration, a hardcoded 30s read timeout in `r_websocket::read_exact` was forcing unnecessary reconnects on idle connections. Bumps to 120s.

## Background
With the recent migration:
- The cloud no longer initiates pings.
- The gateway's `r_websocket_client::_keepalive_loop` sends an RFC 6455 ping every 30s; the server pongs back.
- `r_websocket_client::_receive_loop` calls `recv_frame` → `read_exact` → `r_recv` with a hardcoded 30s timeout.

So on a healthy connection the gateway expects inbound traffic at least every 30s — but if a single pong is delayed (NAT hiccup, sleep/wake, transient cloud load), the read times out, the receive loop catches \"recv timeout\", flips `_connected = false`, and the connection gets recycled.

## Observed in the field
Live laptop, gateway running fine, no actual network fault:

```
2026-04-29T06:12:15.857Z Revere Cloud: Stream f27f8e53… timed out (running > 10 mins). Stopping.
2026-04-29T06:13:02.205Z recv timeout
                          [#10] r_socket_exception (in libr_utils.dylib) (r_socket.cpp:351)
                          [#9]  r_recv()                                   (r_socket.cpp:405)
                          [#8]  read_exact()                               (r_websocket.cpp:181)
                          [#7]  recv_frame()                               (r_websocket.cpp:85)
                          [#6]  r_websocket_client::_receive_loop()        (r_websocket_client.cpp:113)
```

47s of quiet after a stream teardown was enough. With the new behavior, that exact same scenario stays connected.

## Fix
Bump `timeout_ms` in `r_websocket::read_exact` from 30000 to 120000 — 4x the keepalive interval, so the connection has to be silent through several ping cycles before being declared dead.

## True deadness still detected promptly
- `recv` returning 0 (clean TCP FIN) still throws \"Socket closed\" immediately.
- `keepalive_loop`'s `send_ping` failing still flips `_connected = false` on the next 30s tick.

So genuine connection death still surfaces within seconds. Only the idle-misclassified case is fixed.

## Test plan
- [ ] Connect a gateway, leave idle for 5+ minutes — no \"recv timeout\" log entries.
- [ ] Sleep + wake the laptop — connection recovers without an idle-timeout-triggered reconnect (or recovers via the keepalive failure path if the socket was actually severed).
- [ ] Pull the network cable for 30s and reconnect — connection eventually fails over via keepalive (still works as before for true deadness).

## Companion fix
Goes hand-in-hand with revere_cloud PR #13 (dicroce/revere_cloud#13) — the WS reconnect path + cloud_stream::stop() deadlock fix.