### PR TITLE
fix: catch exceptions in r_muxer destructor to prevent std::terminate()

### DIFF
--- a/libs/r_av/source/r_muxer.cpp
+++ b/libs/r_av/source/r_muxer.cpp
@@ -1,6 +1,7 @@
 
 #include "r_av/r_muxer.h"
 #include "r_utils/r_exception.h"
+#include "r_utils/r_logger.h"
 #include "r_utils/r_string_utils.h"
 
 using namespace std;
@@ -58,7 +59,11 @@ r_muxer::r_muxer(const std::string& path, bool output_to_buffer, const std::stri
 r_muxer::~r_muxer()
 {
     if(_needs_finalize)
-        finalize();
+    {
+        try { finalize(); }
+        catch(std::exception& ex) { R_LOG_ERROR("r_muxer finalize failed in destructor: %s", ex.what()); }
+        catch(...) { R_LOG_ERROR("r_muxer finalize failed in destructor: unknown exception"); }
+    }
 }
 
 void r_muxer::add_video_stream(AVRational frame_rate, AVCodecID codec_id, uint16_t w, uint16_t h, int profile, int level)


### PR DESCRIPTION
## Summary
- `r_muxer::~r_muxer()` called `finalize()` unprotected, which calls `av_write_trailer()` via FFmpeg
- If the trailer write fails (e.g. I/O error), `finalize()` throws, propagating out of the destructor and triggering `std::terminate()` → crash
- This was observed in production: a frame write failed at 21:29 (caught in the worker thread), leaving `_needs_finalize` true; when the stream was stopped at 21:35, the destructor called `finalize()` again, `av_write_trailer()` failed again, and the exception escaped → crash
- Wrapped the `finalize()` call in the destructor with a try/catch that logs via `R_LOG_ERROR` instead of propagating
- Also added `r_logger.h` include to support the logging call