### PR TITLE
fix: prevent tray Exit from hanging SDL event loop on macOS

### DIFF
--- a/apps/revere/source/main.cpp
+++ b/apps/revere/source/main.cpp
@@ -1647,7 +1647,7 @@ int main(int argc, char** argv)
     _set_window_icon(window);
 #endif
 
-    bool close_requested = false;
+    std::atomic<bool> close_requested{false};
     bool user_close_handled = false;
 
     R_LOG_INFO("wd=%s\n",r_fs::working_directory().c_str());
@@ -1659,7 +1659,6 @@ int main(int argc, char** argv)
     Tray::Tray tray("Revere", icon_path);
     tray.addEntry(Tray::Button("Exit", [&]{
         close_requested = true;
-        tray.exit();
     }));
     tray.addEntry(Tray::Button("Show", [&]{
         SDL_ShowWindow(window);
@@ -1785,7 +1784,6 @@ int main(int argc, char** argv)
                     {
                         // OS-initiated quit (system shutdown/restart). Actually quit.
                         close_requested = true;
-                        tray.exit();
                     }
                 }
                 if (event.type == SDL_WINDOWEVENT)
@@ -1836,14 +1834,12 @@ int main(int argc, char** argv)
         if(hQuitEvent && WaitForSingleObject(hQuitEvent, 0) == WAIT_OBJECT_0)
         {
             close_requested = true;
-            tray.exit();
         }
 #endif
 #if defined(IS_LINUX) || defined(IS_MACOS)
         if(g_sigterm_received)
         {
             close_requested = true;
-            tray.exit();
         }
 #endif
 
@@ -1920,7 +1916,6 @@ int main(int argc, char** argv)
         auto client_top = revere::main_menu(
             [&](){
                 close_requested = true;
-                tray.exit();
             },
             [&](){
                 camera_setup_wizard.next("minimize_to_tray");
@@ -2224,6 +2219,8 @@ int main(int argc, char** argv)
 
         SDL_RenderPresent(renderer);
     }
+
+    tray.exit();
 
     // Cleanup — order matters:
     // 1. Stop background workers first so they stop touching SDL textures


### PR DESCRIPTION
## Root cause

`tray.exit()` calls `[NSApp stop:nil]` (macOS tray implementation). When called from inside a tray button callback or an SDL event handler — both of which fire during NSApp's event dispatch — this tells NSApp to stop its run loop mid-dispatch. SDL2 on macOS drives event delivery through NSApp, so after this call, `SDL_WaitEventTimeout` stalls indefinitely rather than returning after its 100ms timeout. The main loop is frozen and `close_requested` is never re-evaluated.

## Fix

- Remove all `tray.exit()` calls from inside the main loop. Setting `close_requested = true` is sufficient — the `while(!close_requested)` check exits the loop on the next iteration.
- Call `tray.exit()` once, cleanly, after the loop exits.
- Make `close_requested` `std::atomic<bool>` since it can be written from the tray callback thread and read from the main thread.