### PR TITLE
feat: add per-object bounding boxes to analytics detections

### DIFF
--- a/apps/vision/include/analytics_event.h
+++ b/apps/vision/include/analytics_event.h
@@ -13,6 +13,7 @@ struct analytics_detection
     std::string class_name;
     float confidence;
     std::chrono::system_clock::time_point timestamp;
+    float x1 = 0, y1 = 0, x2 = 0, y2 = 0;  // normalized 0-1 (letterbox coords / 640)
 };
 
 struct analytics_event

--- a/apps/vision/source/query.cpp
+++ b/apps/vision/source/query.cpp
@@ -217,6 +217,10 @@ vector<analytics_event> vision::query_analytics(const configure_state& cs, const
             ad.class_name = det["class_name"].get<string>();
             ad.confidence = det["confidence"].get<float>();
             ad.timestamp = r_time_utils::iso_8601_to_tp(det["timestamp"]);
+            ad.x1 = det.value("x1", 0.0f);
+            ad.y1 = det.value("y1", 0.0f);
+            ad.x2 = det.value("x2", 0.0f);
+            ad.y2 = det.value("y2", 0.0f);
             ae.detections.push_back(ad);
         }
 

--- a/libs/r_vss/motion_plugins/yolov8_motion_plugin/source/yolov8_motion_plugin.cpp
+++ b/libs/r_vss/motion_plugins/yolov8_motion_plugin/source/yolov8_motion_plugin.cpp
@@ -577,9 +577,19 @@ void yolov8_motion_plugin::_analyze_and_log_detections(const std::string& camera
         char conf_buf[32];
         snprintf(conf_buf, sizeof(conf_buf), "%.3f", detection.score);
 
+        char x1_buf[16], y1_buf[16], x2_buf[16], y2_buf[16];
+        snprintf(x1_buf, sizeof(x1_buf), "%.4f", detection.x1 / 640.0f);
+        snprintf(y1_buf, sizeof(y1_buf), "%.4f", detection.y1 / 640.0f);
+        snprintf(x2_buf, sizeof(x2_buf), "%.4f", detection.x2 / 640.0f);
+        snprintf(y2_buf, sizeof(y2_buf), "%.4f", detection.y2 / 640.0f);
+
         json_metadata += R"({"timestamp": ")" + det_time_str +
                         R"(", "class_name": ")" + class_name +
-                        R"(", "confidence": )" + conf_buf + "}";
+                        R"(", "confidence": )" + conf_buf +
+                        R"(, "x1": )" + x1_buf +
+                        R"(, "y1": )" + y1_buf +
+                        R"(, "x2": )" + x2_buf +
+                        R"(, "y2": )" + y2_buf + "}";
     }
 
     json_metadata += R"(], "total_detections": )" + std::to_string(valid_detection_count) + "}}";

--- a/libs/r_vss/source/r_ws.cpp
+++ b/libs/r_vss/source/r_ws.cpp
@@ -34,7 +34,7 @@ using namespace std::chrono;
 using namespace std::placeholders;
 using json = nlohmann::json;
 
-const int WEB_SERVER_PORT = 8088;
+const int WEB_SERVER_PORT = 10080;
 
 namespace {
 

--- a/libs/r_vss/source/r_ws.cpp
+++ b/libs/r_vss/source/r_ws.cpp
@@ -34,7 +34,7 @@ using namespace std::chrono;
 using namespace std::placeholders;
 using json = nlohmann::json;
 
-const int WEB_SERVER_PORT = 10080;
+const int WEB_SERVER_PORT = 8088;
 
 namespace {
 


### PR DESCRIPTION
## Summary

YOLOv8 already computes per-object bounding boxes during inference but they were discarded before analytics storage. This PR preserves them so they flow end-to-end to belfry.

- `analytics_event.h` — adds `float x1, y1, x2, y2` (normalized 0-1) to `analytics_detection`
- `yolov8_motion_plugin.cpp` — serializes bbox as JSON fields in each detection object (raw 0-639 letterbox coords divided by 640.0)
- `apps/vision/source/query.cpp` — extracts bbox fields when parsing the `/analytics` HTTP response

`revere_cloud` passes the analytics JSON blob through transparently in both the push path and WebSocket command-response path, so no changes needed there — bbox fields flow to belfry automatically.