### PR TITLE
fix(windows): bundle opencv_dnn4120.dll required by opencv_video

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -179,12 +179,13 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     file(TO_CMAKE_PATH $ENV{GST_TOP_DIR} GST_TOP_DIR)
     file(TO_CMAKE_PATH $ENV{OPENCV_TOP_DIR} OPENCV_TOP_DIR)
     
-    # Define OpenCV modules list for easier maintenance
-    # NOTE: only core (non-contrib) modules are needed. Motion detection uses
-    # cv::BackgroundSubtractorMOG2 which lives in opencv_video, not contrib.
-    # opencv_dnn is intentionally excluded: we infer via NCNN, and dnn drags in
-    # libprotobuf (a duplicate-protobuf load from a separately built plugin
-    # crashed the app on macOS). Keep this list in sync with dependencies.cmake.
+    # OpenCV modules that Revere LINKS against (keep in sync with the link list
+    # in dependencies.cmake). Only core (non-contrib) modules are needed: motion
+    # detection uses cv::BackgroundSubtractorMOG2, which lives in opencv_video,
+    # not contrib. We deliberately do NOT link opencv_dnn (we infer via NCNN, and
+    # dnn drags in libprotobuf). NOTE: dnn must still be SHIPPED on Windows as a
+    # runtime DLL even though we don't link it -- see the opencv_dnn install
+    # below for the why.
     set(OPENCV_MODULES
         opencv_calib3d
         opencv_core
@@ -232,14 +233,35 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     # Use generator expressions to handle multi-config generators (like Visual Studio)
     foreach(module ${OPENCV_MODULES})
         install(
-            FILES 
+            FILES
                 "$<$<CONFIG:Debug>:${OPENCV_TOP_DIR}/x64/vc17/bin/${module}4120d.dll>"
                 "$<$<NOT:$<CONFIG:Debug>>:${OPENCV_TOP_DIR}/x64/vc17/bin/${module}4120.dll>"
             DESTINATION revere
             OPTIONAL
         )
     endforeach()
-    
+
+    # Ship opencv_dnn4120.dll even though Revere never links or calls cv::dnn.
+    # The prebuilt Windows OpenCV (revere-deps contrib build) compiles the video
+    # module WITH dnn enabled, so opencv_video4120.dll -- which we MUST ship for
+    # MOG2 -- has a load-time import of opencv_dnn4120.dll. Without this DLL the
+    # app fails to start on a clean machine with:
+    #     "The code execution cannot proceed because opencv_dnn4120.dll was not
+    #      found."
+    # It loads on dev machines only because OPENCV_TOP_DIR\x64\vc17\bin is on PATH.
+    # opencv_dnn4120.dll is self-contained here (statically links protobuf; only
+    # needs opencv_core + opencv_imgproc, already shipped), so this adds exactly
+    # one DLL and no new transitive deps. This is Windows-ONLY: on macOS/Linux the
+    # Homebrew/system OpenCV's video module does not reference dnn, which is why
+    # this lives inside the Windows block and is absent from those packages.
+    install(
+        FILES
+            "$<$<CONFIG:Debug>:${OPENCV_TOP_DIR}/x64/vc17/bin/opencv_dnn4120d.dll>"
+            "$<$<NOT:$<CONFIG:Debug>>:${OPENCV_TOP_DIR}/x64/vc17/bin/opencv_dnn4120.dll>"
+        DESTINATION revere
+        OPTIONAL
+    )
+
     # Install GStreamer plugins (remains the same)
     install(
         FILES

--- a/scripts/windows/build_installers.py
+++ b/scripts/windows/build_installers.py
@@ -30,6 +30,28 @@ from pathlib import Path
 import argparse
 
 
+# DLLs provided by Windows itself or the bundled VC++ redistributable. An import
+# of one of these is NOT a packaging error even though the file isn't staged.
+# Anything matching is treated as "resolvable on a clean machine".
+SYSTEM_DLL_RE = re.compile(
+    r"^(?:"
+    r"api-ms-win-.*|ext-ms-win-.*|"                      # API set stubs
+    r"msvcp140.*|vcruntime140.*|concrt140|msvcrt|"       # VC++ runtime (VCRedist)
+    r"kernel32|kernelbase|ntdll|user32|gdi32|gdiplus|"
+    r"advapi32|shell32|shlwapi|ole32|oleaut32|combase|"
+    r"rpcrt4|sechost|ws2_32|wsock32|crypt32|secur32|"
+    r"bcrypt|ncrypt|dnsapi|iphlpapi|winmm|setupapi|"
+    r"cfgmgr32|comctl32|comdlg32|version|userenv|psapi|"
+    r"dbghelp|powrprof|wtsapi32|imm32|uxtheme|propsys|"
+    r"dwmapi|d3d9|d3d11|d3d12|dxgi|d3dcompiler.*|"
+    r"opengl32|glu32|d2d1|dwrite|mf|mfplat|mfreadwrite|"  # d2d1/dwrite: pulled by avcodec
+    r"mfcore|avicap32|vfw32|winhttp|wininet|urlmon|"
+    r"normaliz|bcryptprimitives|win32u|gdi32full|msvcp_win"
+    r")\.dll$",
+    re.IGNORECASE,
+)
+
+
 # Configuration — every path is overridable via an environment variable (for CI)
 # and falls back to the historical local-dev default when the variable is unset.
 REVERE_DIR = Path(os.environ.get("REVERE_DIR", r"c:\dev\revere"))
@@ -177,6 +199,73 @@ def install_binaries():
     run_command(cmd, cwd=BUILD_DIR, description=f"Installing binaries to {INSTALL_DIR}")
 
 
+def verify_dependencies():
+    """Fail the build if any staged binary imports a DLL we don't ship.
+
+    Walks every .exe/.dll under STAGING_DIR, reads its import table with
+    dumpbin, and flags any imported DLL that is neither present somewhere in the
+    staged tree nor a known system/VCRedist DLL. This is the guard that would
+    have caught the opencv_dnn4120.dll regression: opencv_video4120.dll imports
+    opencv_dnn4120.dll, which loads on dev machines (OpenCV bin is on PATH) but
+    is absent on a clean install -> startup failure. A missing third-party DLL
+    here is a release blocker.
+    """
+    print(f"\n{'='*60}")
+    print("  Verifying bundled DLL dependencies")
+    print(f"{'='*60}")
+
+    if not STAGING_DIR.exists():
+        print(f"WARNING: staging dir not found ({STAGING_DIR}); skipping check.")
+        return
+
+    dumpbin = shutil.which("dumpbin")
+    if not dumpbin:
+        # dumpbin ships with MSVC and is on PATH in the x64 Native Tools prompt
+        # (and in CI after msvc-dev-cmd). If it's missing we can't verify; warn
+        # loudly rather than block the build on tooling.
+        print("WARNING: dumpbin not found on PATH; cannot verify dependencies.")
+        return
+
+    binaries = [p for p in STAGING_DIR.rglob("*")
+                if p.suffix.lower() in (".dll", ".exe")]
+    present = {p.name.lower() for p in binaries}
+
+    dep_line = re.compile(r"^\s+(\S+\.dll)\s*$", re.IGNORECASE)
+    missing = {}  # missing dll (lower) -> set of importers
+    for binary in binaries:
+        try:
+            out = subprocess.run(
+                [dumpbin, "/dependents", str(binary)],
+                capture_output=True, text=True, check=True,
+            ).stdout
+        except subprocess.CalledProcessError as e:
+            print(f"WARNING: dumpbin failed on {binary.name}: {e}")
+            continue
+        for line in out.splitlines():
+            m = dep_line.match(line)
+            if not m:
+                continue
+            dep = m.group(1)
+            dep_l = dep.lower()
+            if dep_l in present or SYSTEM_DLL_RE.match(dep):
+                continue
+            missing.setdefault(dep_l, set()).add(binary.name)
+
+    if missing:
+        print("\nERROR: staged binaries import DLLs that are not bundled and are")
+        print("not known system DLLs. The installer would fail on a clean machine:\n")
+        for dep in sorted(missing):
+            importers = ", ".join(sorted(missing[dep]))
+            print(f"  MISSING: {dep}   <- imported by: {importers}")
+        print("\nFix: bundle the DLL (see the OpenCV install block in")
+        print("apps/CMakeLists.txt for the pattern) or stop linking it, then")
+        print("rebuild. If a flagged DLL is genuinely a system DLL, add it to")
+        print("SYSTEM_DLL_RE in this script.")
+        sys.exit(1)
+
+    print(f"OK: all imports of {len(binaries)} staged binaries are bundled or system DLLs.")
+
+
 def compile_inno_setup(iss_file, project_dir, project_name, defines=None):
     """Compile Inno Setup script.
 
@@ -302,6 +391,11 @@ def main():
         install_binaries()
     else:
         print("\nSkipping install step (--skip-install)")
+
+    # Gate: every DLL the staged binaries import must be bundled or a system DLL.
+    # Catches the class of bug where a dependency resolves on the dev machine
+    # (deps bin dir on PATH) but is missing from the installed package.
+    verify_dependencies()
 
     # Inno Setup compilation
     if not args.skip_inno:


### PR DESCRIPTION
## Problem

A user reported `revere.exe - System Error: opencv_dnn4120.dll was not found` on a clean install of a release build (no compilation on their end). It reproduces on **every release through v0.0.24** but not on dev machines.

**Root cause:** the prebuilt Windows OpenCV+contrib (from revere-deps) compiles the video module with dnn enabled, so `opencv_video4120.dll` — which we must ship for MOG2 — has a load-time import of `opencv_dnn4120.dll`. Revere never links or calls `cv::dnn` (we infer via NCNN), and the installer never bundled dnn, so the dependency only resolved on dev machines because `OPENCV_TOP_DIR\x64\vc17\bin` is on PATH. On a clean machine the loader can't find it → startup failure.

The earlier `7029bd0` dnn-link removal was unrelated — it changed what *our* code links, not what's baked inside `opencv_video`.

## Fix

- **Bundle `opencv_dnn4120.dll`** in the Windows-only OpenCV install block of `apps/CMakeLists.txt`. It's self-contained here (statically links protobuf; only needs core+imgproc, already shipped) → one DLL, no new transitive deps.
- **Windows-only by design.** macOS/Linux use Homebrew/system OpenCV whose video module does not reference dnn (confirmed: the macOS protobuf-crash fix worked by merely dropping dnn from our link list, which only holds if `libopencv_video.dylib` doesn't reference dnn). The change lives inside the existing `if(Windows)` block; macOS bundling is a separate code path.
- **Dependency-completeness gate** added to `scripts/windows/build_installers.py` (`verify_dependencies()`): after install, `dumpbin`-scan every staged binary and fail the build on any imported DLL that's neither bundled nor a known system DLL. Turns this whole bug class into a build failure instead of a user report.

## Verification

- Gate on the pre-fix stage → fails, flagging exactly `opencv_dnn4120.dll` (imported by `opencv_video4120.dll`), no false positives.
- Reconfigure + install → `opencv_dnn4120.dll` now staged.
- Gate re-run → green: "all imports of 64 staged binaries are bundled or system DLLs."

## Follow-up

- Cut a new release (e.g. v0.0.25); `--clean` CI builds will bundle dnn and the gate guards it. Reporter should install that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
