### PR TITLE
fix: preserve aspect ratio when scaling jpg/webp snapshots

### DIFF
--- a/libs/r_vss/source/r_query.cpp
+++ b/libs/r_vss/source/r_query.cpp
@@ -52,14 +52,44 @@ static bool _has_inline_sps(const vector<uint8_t>& frame)
     return false;
 }
 
-// Helper: decode a single frame with proper parser and flush support
+// Helper: scale (src_w x src_h) to fit *inside* the (w x h) box while preserving
+// aspect ratio, writing the fitted dimensions back into w/h. The result never
+// exceeds the box on either axis and is never upscaled past the source's native
+// resolution. Dimensions are rounded to even (4:2:0 encoders require it) and
+// clamped to a sane minimum. A zero source or box dimension leaves w/h untouched.
+static void _fit_inside(uint16_t src_w, uint16_t src_h, uint16_t& w, uint16_t& h)
+{
+    if(src_w == 0 || src_h == 0 || w == 0 || h == 0)
+        return;
+
+    double sx = (double)w / (double)src_w;
+    double sy = (double)h / (double)src_h;
+    double scale = (sx < sy) ? sx : sy;
+    if(scale > 1.0) scale = 1.0;  // never upscale beyond native resolution
+
+    int ow = (int)((double)src_w * scale + 0.5);
+    int oh = (int)((double)src_h * scale + 0.5);
+    ow &= ~1; oh &= ~1;           // even dimensions for 4:2:0 encoders
+    if(ow < 2) ow = 2;
+    if(oh < 2) oh = 2;
+
+    w = (uint16_t)ow;
+    h = (uint16_t)oh;
+}
+
+// Helper: decode a single frame with proper parser and flush support.
+// When preserve_aspect is true, w/h are treated as a bounding box: the frame is
+// scaled to fit inside while preserving aspect ratio, and w/h are overwritten
+// with the actual output dimensions (so callers can size their encoder to match).
+// When false, the frame is scaled to exactly w x h (legacy stretch behavior).
 static shared_ptr<vector<uint8_t>> _decode_single_frame(
     const string& video_codec_name,
     const string& video_codec_parameters,
     const vector<uint8_t>& frame,
     AVPixelFormat output_format,
-    uint16_t w,
-    uint16_t h)
+    uint16_t& w,
+    uint16_t& h,
+    bool preserve_aspect = false)
 {
     // Enable parsing to properly handle Annex B streams with multiple NAL units
     auto codec_id = r_av::encoding_to_av_codec_id(video_codec_name);
@@ -90,7 +120,11 @@ static shared_ptr<vector<uint8_t>> _decode_single_frame(
     }
 
     if(ds == R_CODEC_STATE_HAS_OUTPUT || ds == R_CODEC_STATE_AGAIN_HAS_OUTPUT)
+    {
+        if(preserve_aspect)
+            _fit_inside(decoder.input_width(), decoder.input_height(), w, h);
         return decoder.get(output_format, w, h, 1);
+    }
 
     return nullptr;
 }
@@ -125,7 +159,9 @@ vector<uint8_t> r_vss::query_get_jpg(const std::string& top_dir, r_devices& devi
 
     auto frame = bt["frames"][0]["data"].get_blob();
 
-    auto decoded = _decode_single_frame(video_codec_name, video_codec_parameters, frame, AV_PIX_FMT_YUVJ420P, w, h);
+    // Treat w/h as a bounding box; _decode_single_frame rewrites them with the
+    // aspect-preserved output dimensions, which the encoder must then match.
+    auto decoded = _decode_single_frame(video_codec_name, video_codec_parameters, frame, AV_PIX_FMT_YUVJ420P, w, h, true);
 
     if(decoded)
     {
@@ -448,7 +484,9 @@ vector<uint8_t> r_vss::query_get_webp(const string& top_dir, r_devices& devices,
 
     auto frame = bt["frames"][0]["data"].get_blob();
 
-    auto decoded = _decode_single_frame(video_codec_name, video_codec_parameters, frame, AV_PIX_FMT_YUV420P, w, h);
+    // Treat w/h as a bounding box; _decode_single_frame rewrites them with the
+    // aspect-preserved output dimensions, which the encoder must then match.
+    auto decoded = _decode_single_frame(video_codec_name, video_codec_parameters, frame, AV_PIX_FMT_YUV420P, w, h, true);
 
     if(decoded)
     {

--- a/libs/r_vss/source/r_ws.cpp
+++ b/libs/r_vss/source/r_ws.cpp
@@ -228,13 +228,23 @@ r_http::r_server_response r_ws::_get_jpg(const r_http::r_web_server<r_utils::r_s
         if(args.find("start_time") == end(args))
             R_THROW(("Missing start_time."));
 
-        uint16_t w = 640;
-        if(args.find("width") != end(args))
-            w = r_string_utils::s_to_uint16(args["width"]);
-
-        uint16_t h = 480;
-        if(args.find("height") != end(args))
-            h = r_string_utils::s_to_uint16(args["height"]);
+        // w/h are a bounding box (query_get_jpg preserves aspect ratio inside it).
+        // long_edge=N is shorthand for an NxN box, i.e. "cap the longer edge at N"
+        // regardless of camera orientation.
+        uint16_t w = 640, h = 480;
+        if(args.find("long_edge") != end(args))
+        {
+            uint16_t le = r_string_utils::s_to_uint16(args["long_edge"]);
+            w = le;
+            h = le;
+        }
+        else
+        {
+            if(args.find("width") != end(args))
+                w = r_string_utils::s_to_uint16(args["width"]);
+            if(args.find("height") != end(args))
+                h = r_string_utils::s_to_uint16(args["height"]);
+        }
 
         auto result = query_get_jpg(
             _top_dir,
@@ -272,13 +282,23 @@ r_http::r_server_response r_ws::_get_webp(const r_http::r_web_server<r_utils::r_
         if(args.find("start_time") == end(args))
             R_THROW(("Missing start_time."));
 
-        uint16_t w = 640;
-        if(args.find("width") != end(args))
-            w = r_string_utils::s_to_uint16(args["width"]);
-
-        uint16_t h = 480;
-        if(args.find("height") != end(args))
-            h = r_string_utils::s_to_uint16(args["height"]);
+        // w/h are a bounding box (query_get_webp preserves aspect ratio inside it).
+        // long_edge=N is shorthand for an NxN box, i.e. "cap the longer edge at N"
+        // regardless of camera orientation.
+        uint16_t w = 640, h = 480;
+        if(args.find("long_edge") != end(args))
+        {
+            uint16_t le = r_string_utils::s_to_uint16(args["long_edge"]);
+            w = le;
+            h = le;
+        }
+        else
+        {
+            if(args.find("width") != end(args))
+                w = r_string_utils::s_to_uint16(args["width"]);
+            if(args.find("height") != end(args))
+                h = r_string_utils::s_to_uint16(args["height"]);
+        }
 
         auto result = query_get_webp(
             _top_dir,


### PR DESCRIPTION
## Problem

\`query_get_jpg\`/\`query_get_webp\` scaled every frame to exactly the requested \`w x h\` via \`sws_scale\`, **stretching any source whose aspect ratio differed from the request**:

- a 4:3 camera squished horizontally into a 16:9 box
- a 16:9 camera squished vertically into the \`640x480\` default

The distortion is baked into the encoded image, so display-side \`resizeMode\` (lantern's \`cover\`/\`contain\`) cannot correct it. This affects **every** consumer of the \`/jpg\` and \`/webp\` endpoints — snapshots, thumbnails, AI/vision-analysis frames, and the proactively-pushed event frames (revere_cloud PR #22).

## Fix

Treat \`w\`/\`h\` as a **bounding box** instead of an exact size:

- \`_decode_single_frame\` gains a \`preserve_aspect\` flag that fits the frame inside \`w x h\` preserving aspect ratio (never upscaling past native, even dimensions for 4:2:0), and writes the actual output dimensions back so the encoder matches.
- \`query_get_jpg\`/\`query_get_webp\` opt in; the internal \`bgr24\`/\`rgb24\` and measure-camera paths keep exact-scale behavior (they feed fixed-size motion/AI buffers).
- Added a \`long_edge=N\` query param to \`/jpg\` and \`/webp\` (an \`NxN\` box, i.e. cap the longer edge regardless of orientation) for callers that want the largest aspect-correct frame without assuming a 16:9 source.

## Behavior change for reviewers

The \`width\`/\`height\` params on \`/jpg\` and \`/webp\` change semantics from **"exact output size"** to **"bounding box"** — returned images may be smaller than the box on one axis, never larger, never stretched. Nothing in the system relies on exact dimensions (display paths use \`cover\`/\`contain\`; belfry's KV key is keyed by the *requested* dims, which still works as a cache key).

## Follow-up

revere_cloud PR #22 (event-frame push) will switch to \`long_edge=1600\` once this lands, so the merge order is **revere → revere_cloud**.

## Testing

- \`r_vss\` builds cleanly against current \`main\`.