### PR TITLE
fix(windows): link FFmpeg by absolute path to avoid GStreamer avutil.lib shadowing

### DIFF
--- a/dependencies.cmake
+++ b/dependencies.cmake
@@ -293,8 +293,15 @@ if(NOT TARGET ffmpeg::ffmpeg)
         target_link_directories(ffmpeg::ffmpeg INTERFACE "${FFMPEG_ROOT}/lib")
 
         if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+            # Link by absolute path: GStreamer's lib dir also contains an
+            # avutil.lib (from its bundled FFmpeg), and bare names let the
+            # linker resolve against whichever -libpath comes first.
             target_link_libraries(ffmpeg::ffmpeg INTERFACE
-                avcodec.lib avformat.lib avutil.lib swscale.lib swresample.lib
+                "${FFMPEG_ROOT}/lib/avcodec.lib"
+                "${FFMPEG_ROOT}/lib/avformat.lib"
+                "${FFMPEG_ROOT}/lib/avutil.lib"
+                "${FFMPEG_ROOT}/lib/swscale.lib"
+                "${FFMPEG_ROOT}/lib/swresample.lib"
             )
         else()
             # Linux/macOS with explicit path


### PR DESCRIPTION
## Problem

On Windows, GStreamer's MSVC distribution (`C:\Program Files\gstreamer\1.0\msvc_x86_64\lib`) ships its own `avutil.lib` import library from its bundled FFmpeg 7.x. `r_vss` links both `gstreamer::gstreamer` and `ffmpeg::ffmpeg`, so both lib directories end up on the linker's `-libpath` search path.

Because the Windows branch of the `ffmpeg::ffmpeg` INTERFACE target linked FFmpeg by **bare names** (`avcodec.lib avformat.lib avutil.lib ...`), the MSVC linker resolved `avutil.lib` from whichever `-libpath` happened to come first — GStreamer's. The result:

- `r_vss.dll` imports `avutil-59.dll` (GStreamer's bundled FFmpeg)
- `r_av.dll` imports `avutil-60.dll` (the standalone `FFMPEG_TOP_DIR` install)

That is two different FFmpeg runtimes loaded into one process — a latent ABI hazard on every Windows dev machine — and it became a hard failure after upgrading the standalone FFmpeg install: `revere.exe` failed to launch with *"avutil-59.dll was not found"*, since only the standalone FFmpeg's DLLs are staged next to the binaries.

## Fix

Link the `FFMPEG_TOP_DIR` libraries by **absolute path** on Windows so the intended FFmpeg import libs always win regardless of `-libpath` ordering. Only the Windows/`FFMPEG_TOP_DIR` branch of `dependencies.cmake` changes.

## Verification

Fresh Release configure + build of `r_av` and `r_vss` on Windows (MSVC 19.44, standalone FFmpeg 8.1 in `FFMPEG_TOP_DIR`), then `dumpbin -dependents`:

- `r_vss.dll` → `avutil-60.dll` ✅ (previously `avutil-59.dll`)
- `r_av.dll` → `avcodec-62.dll`, `avformat-62.dll`, `avutil-60.dll`, `swscale-9.dll`, `swresample-6.dll` ✅

One FFmpeg runtime in the process, matching the DLLs staged to `bin/Release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
