### PR TITLE
fix: TLS 1.3 handshake failure when mbedtls is built with GCC 15+

### DIFF
--- a/libs/r_utils/CMakeLists.txt
+++ b/libs/r_utils/CMakeLists.txt
@@ -21,6 +21,16 @@ set(USE_SHARED_MBEDTLS_LIBRARY OFF CACHE BOOL "Disable shared mbedtls libraries"
 set(MBEDTLS_CONFIG_FILE "${CMAKE_CURRENT_SOURCE_DIR}/include/mbedtls/mbedtls_config.h" CACHE STRING "Custom mbedtls config")
 set(MBEDTLS_USER_CONFIG_FILE "${CMAKE_CURRENT_SOURCE_DIR}/include/mbedtls/user_config.h" CACHE STRING "Custom user config")
 
+# GCC 15+ no longer zero-fills the non-first members of a union initialized
+# with {0}, leaving mbedtls 3.6.x PSA operation structs with garbage in
+# ctx.hmac.hash.id — every TLS 1.3 handshake then fails at the Finished
+# message with MBEDTLS_ERR_SSL_INTERNAL_ERROR (PSA_ERROR_BAD_STATE).
+include(CheckCCompilerFlag)
+check_c_compiler_flag("-fzero-init-padding-bits=unions" C_HAS_ZERO_INIT_PADDING_BITS)
+if(C_HAS_ZERO_INIT_PADDING_BITS)
+    add_compile_options($<$<COMPILE_LANGUAGE:C>:-fzero-init-padding-bits=unions>)
+endif()
+
 FetchContent_MakeAvailable(mbedtls)
 
 file(GLOB R_UTILS_HEADERS


### PR DESCRIPTION
## Problem

On distros shipping GCC 15+ (current Arch, upcoming Fedora/Ubuntu toolchains), every TLS 1.3 handshake made through `r_ssl_socket` fails with:

```
mbedtls_ssl_handshake() failed: SSL - Internal error (eg, unexpected failure in lower-level module) (code: -27648)
```

In practice this means the revere_cloud plugin can never reach `api.revere.video` — the gateway shows permanently offline — and any other TLS 1.3 endpoint is equally unreachable. TLS 1.2-only servers still work, which makes the failure look server-specific when it isn't.

## Root cause

GCC 15 changed the semantics of `{0}` initialization for unions: only the first member's bytes are zeroed and the remainder of the union is left unspecified (allowed by the C standard; GCC previously zeroed the whole union). mbedtls 3.6.x's PSA operation structs rely on the old behavior — `MBEDTLS_PSA_MAC_OPERATION_INIT` initializes a union through its small first member, so `ctx.hmac.hash.id` picks up stack garbage. During a TLS 1.3 handshake `psa_hash_setup()` then sees `operation->id != 0`, returns `PSA_ERROR_BAD_STATE`, and the handshake dies at the Finished message with `MBEDTLS_ERR_SSL_INTERNAL_ERROR`.

Verified by stepping through `ssl_tls13_calc_finished_core` in gdb against a `-O0` build: `psa_hash_setup` at `psa_crypto.c:2394` is where BAD_STATE originates. A standalone repro of the same PSA calls succeeds on a clean stack, which is why only in-handshake calls fail — the bug is data-dependent on stack residue.

## Fix

Pass `-fzero-init-padding-bits=unions` — the flag GCC 15 added specifically to restore whole-union zeroing — to the mbedtls build, guarded by `check_c_compiler_flag`:

- GCC 15+: flag is accepted, old (safe) initialization behavior restored, handshakes work.
- clang / MSVC / GCC < 15: the flag check fails, nothing is added, zero behavior change.

The flag is applied with `$<COMPILE_LANGUAGE:C>` so C++ compilation is untouched.

## Backwards compatibility

Fully backwards compatible: on every compiler that doesn't support the flag the build is bit-for-bit unchanged, and on GCC 15+ the flag only restores the initialization semantics all other supported compilers already have.

## Alternative

Bumping the mbedtls `GIT_TAG` to 3.6.4+ also fixes this (upstream corrected the struct initialization). This PR takes the smaller-diff route and keeps 3.6.3; happy to switch to the tag bump if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VsMYKVqBevE4AG34FuyjYi