### PR TITLE
fix: build failure against OpenCV 5 (contourArea/boundingRect moved to geometry module)

### DIFF
--- a/libs/r_motion/include/r_motion/r_motion_state.h
+++ b/libs/r_motion/include/r_motion/r_motion_state.h
@@ -6,6 +6,11 @@
 #include "r_utils/r_nullable.h"
 #include "r_utils/r_macro.h"
 #include <opencv2/opencv.hpp>
+// OpenCV 5 moved contourArea/boundingRect to the geometry module, which the
+// umbrella header no longer includes.
+#if CV_VERSION_MAJOR >= 5
+#include <opencv2/geometry.hpp>
+#endif
 #include <functional>
 
 namespace r_motion


### PR DESCRIPTION
## Problem

OpenCV 5.0 (now shipping as the system package on Arch) moved `cv::contourArea` and `cv::boundingRect` into a new `opencv_geometry` module, and its header is no longer pulled in by the `<opencv2/opencv.hpp>` umbrella. Building r_motion against system OpenCV 5 fails with:

```
r_motion_state.cpp:176: error: 'contourArea' is not a member of 'cv'
r_motion_state.cpp:179: error: 'boundingRect' is not a member of 'cv'
```

## Fix

Include `<opencv2/geometry.hpp>` in `r_motion_state.h` (next to the existing umbrella include), guarded by `#if CV_VERSION_MAJOR >= 5`.

Linking needs no change: pkg-config's `opencv5` module already emits `-lopencv_geometry`.

## Backwards compatibility

Fully backwards compatible — on OpenCV 4.x the preprocessor guard compiles away and the umbrella header already declares both functions, so Windows/macOS/older-Linux builds are unchanged.

Note: building against OpenCV 5 also requires the build system to find it (e.g. `pkg_search_module(OPENCV opencv4 opencv5)` in `dependencies.cmake`); I've kept that out of this PR since supporting OpenCV 5 distro-wide may deserve its own discussion — this change just makes the source code version-proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VsMYKVqBevE4AG34FuyjYi