### PR TITLE
fix: lower default continuous retention 3d -> 1d

### DIFF
--- a/apps/revere/include/assignment_state.h
+++ b/apps/revere/include/assignment_state.h
@@ -36,7 +36,7 @@ struct assignment_state
     r_utils::r_nullable<std::string> rtsp_password;
     std::string camera_friendly_name;
     int64_t byte_rate {64000};
-    double continuous_retention_days {3.0};
+    double continuous_retention_days {1.0};
     int motion_retention_days {10};
     int motion_percentage_estimate {5};
     std::string file_name;


### PR DESCRIPTION
## Why

The gateway disk was hitting ~97% full. The continuous-recording ring files are preallocated as `retention_days × 24 × byte_rate`, and the default retention was **3 days**. On high-bitrate cameras that produced very large files (an ~8 Mbps stream = ~32 GB per camera), which is what filled the disk — retention was already short; bitrate is the size driver, and a shorter default is the cheapest lever.

## Change

- `assignment_state.h`: default `continuous_retention_days` **3.0 → 1.0**.

New cameras now preallocate a 1-day ring (~⅓ the disk). Retention stays per-camera adjustable in the setup UI ("Retention Days") and the `configure_camera` API — this only changes the starting value for newly provisioned cameras. Existing cameras keep their current ring until re-provisioned.

Draft — flagging for review before merge.