### PR TITLE
feat: change retention on an existing camera (desktop)

### DIFF
--- a/apps/revere/include/imgui_ui.h
+++ b/apps/revere/include/imgui_ui.h
@@ -1009,7 +1009,7 @@ void configure_rtsp_source_camera_modal(
     }
 }
 
-template<typename OK_CB, typename CANCEL_CB, typename MOVE_STORAGE_CB>
+template<typename OK_CB, typename CANCEL_CB, typename MOVE_STORAGE_CB, typename CHANGE_RETENTION_CB>
 void camera_properties_modal(
     ImGuiContext*,
     const std::string& name,
@@ -1019,7 +1019,8 @@ void camera_properties_modal(
     const std::string& record_file_path,
     OK_CB ok_cb,
     CANCEL_CB cancel_cb,
-    MOVE_STORAGE_CB move_storage_cb
+    MOVE_STORAGE_CB move_storage_cb,
+    CHANGE_RETENTION_CB change_retention_cb
 )
 {
     if (ImGui::BeginPopupModal(name.c_str(), NULL, ImGuiWindowFlags_AlwaysAutoResize))
@@ -1063,6 +1064,17 @@ void camera_properties_modal(
         ImGui::TextDisabled("(?)");
         if(ImGui::IsItemHovered())
             ImGui::SetTooltip("Move recording files to a new location.\nOptionally start fresh and discard old recordings.");
+
+        ImGui::SameLine();
+        if(ImGui::Button("Change Retention"))
+        {
+            ImGui::CloseCurrentPopup();
+            change_retention_cb();
+        }
+        ImGui::SameLine();
+        ImGui::TextDisabled("(?)");
+        if(ImGui::IsItemHovered())
+            ImGui::SetTooltip("Resize this camera's recording buffer to keep more or fewer days.\nApplying reallocates the ring and clears this camera's existing recordings.");
 
         ImGui::Spacing();
         ImGui::Separator();
@@ -1212,6 +1224,130 @@ void about_revere_cloud_modal(
         }
 
         ImGui::Spacing();
+
+        ImGui::EndPopup();
+    }
+}
+
+// Resize an existing camera's recording ring buffer to a new retention target.
+// Reuses the same async op/phases as move_storage_modal. Sizing mirrors the
+// setup wizard's retention step: block_size/num_blocks are derived from the
+// live byte_rate and the requested days. Applying reallocates the ring, which
+// clears the camera's existing recordings (a fixed-size ring can't be resized
+// in place), so a confirm checkbox is required before Apply is enabled.
+template<typename START_CB, typename CLOSE_CB, typename CANCEL_OP_CB>
+void change_retention_modal(
+    ImGuiContext*,
+    const std::string& name,
+    const std::string& camera_name,
+    int64_t byte_rate,
+    double& retention_days,
+    bool& confirm_delete,
+    int64_t& out_num_blocks,
+    int64_t& out_block_size,
+    float progress,
+    bool running,
+    bool done,
+    bool error,
+    const std::string& status,
+    START_CB start_cb,
+    CLOSE_CB close_cb,
+    CANCEL_OP_CB cancel_op_cb
+)
+{
+    ImGui::SetNextWindowSize(ImVec2(540, 0), ImGuiCond_Always);
+    if(ImGui::BeginPopupModal(name.c_str(), NULL, ImGuiWindowFlags_AlwaysAutoResize))
+    {
+        if(!running && !done)
+        {
+            if(ImGui::IsWindowAppearing())
+                confirm_delete = false;
+
+            ImGui::Text("Camera: %s", camera_name.c_str());
+            if(byte_rate > 0)
+                ImGui::Text("Current bitrate: %lld kbps", (long long)((byte_rate * 8) / 1024));
+            ImGui::Spacing();
+            ImGui::Separator();
+            ImGui::Spacing();
+
+            const bool have_bitrate = (byte_rate > 0);
+            if(!have_bitrate)
+            {
+                ImGui::TextColored(ImVec4(1.f, 0.4f, 0.4f, 1.f),
+                    "This camera has no current bitrate (not receiving video).");
+                ImGui::TextWrapped("Retention is sized from the live bitrate, so the camera must be recording before it can be resized.");
+                ImGui::Spacing();
+            }
+
+            ImGui::BeginDisabled(!have_bitrate);
+            ImGui::InputDouble("Retention Days", &retention_days, 0.0, 0.0, "%.2f");
+            if(retention_days < 0.0)
+                retention_days = 0.0;
+            ImGui::EndDisabled();
+
+            // Derive the ring geometry from days * bitrate (same as setup).
+            if(have_bitrate)
+            {
+                auto sz = r_storage::required_file_size_for_retention_hours((int64_t)(retention_days * 24.0), byte_rate);
+                out_num_blocks = sz.first;
+                out_block_size = sz.second;
+
+                auto human = r_storage::human_readable_file_size((double)(out_num_blocks * out_block_size));
+                ImGui::Spacing();
+                ImGui::Text("New storage size: %s", human.c_str());
+            }
+
+            ImGui::Spacing();
+            ImGui::TextColored(ImVec4(1.f, 0.4f, 0.4f, 1.f),
+                "Applying reallocates the ring and permanently deletes this camera's existing recordings.");
+            ImGui::Checkbox("I understand the existing recordings will be deleted", &confirm_delete);
+
+            ImGui::Spacing();
+            ImGui::Separator();
+            ImGui::Spacing();
+
+            if(ImGui::Button("Cancel", ImVec2(120, 30)))
+            {
+                ImGui::CloseCurrentPopup();
+                close_cb();
+            }
+
+            ImGui::SameLine();
+
+            bool can_start = have_bitrate && retention_days > 0.0 && confirm_delete;
+            ImGui::BeginDisabled(!can_start);
+            if(ImGui::Button("Apply", ImVec2(120, 30)))
+                start_cb();
+            ImGui::EndDisabled();
+        }
+        else if(running)
+        {
+            ImGui::Text("Resizing recording buffer...");
+            ImGui::Spacing();
+            ImGui::ProgressBar(progress, ImVec2(-1, 0));
+            ImGui::Spacing();
+            ImGui::TextWrapped("%s", status.c_str());
+            ImGui::Spacing();
+            if(ImGui::Button("Cancel", ImVec2(120, 30)))
+                cancel_op_cb();
+        }
+        else if(done && !error)
+        {
+            ImGui::CloseCurrentPopup();
+            close_cb();
+        }
+        else if(error)
+        {
+            ImGui::TextColored(ImVec4(1.f, 0.3f, 0.3f, 1.f), "Error:");
+            ImGui::Spacing();
+            ImGui::TextWrapped("%s", status.c_str());
+            ImGui::Spacing();
+            if(ImGui::Button("Close", ImVec2(120, 30)))
+            {
+                ImGui::CloseCurrentPopup();
+                close_cb();
+            }
+        }
 
         ImGui::EndPopup();
     }

--- a/apps/revere/source/main.cpp
+++ b/apps/revere/source/main.cpp
@@ -466,6 +466,12 @@ struct storage_op_state
     std::atomic<bool> cancel_requested{false};
     bool start_fresh{false};
     bool delete_confirmed{false};
+
+    // Change-retention op: target ring geometry derived from byte_rate + days.
+    double retention_days{0.0};
+    int64_t byte_rate{0};
+    int64_t new_num_blocks{0};
+    int64_t new_block_size{0};
 };
 
 static storage_op_state s_storage_op;
@@ -726,6 +732,71 @@ static void _do_reset_storage(
         devices.save_camera(camera);
 
         set_status("Reset complete. Recording will resume.");
+        op.progress = 1.f;
+        op.done = true;
+        op.running = false;
+        stream_keeper.resume(camera.id);
+    }
+    catch(const std::exception& e)
+    {
+        set_status(string("Error: ") + e.what());
+        op.error = true;
+        op.running = false;
+        stream_keeper.resume(camera.id);
+    }
+}
+
+// Reallocate a camera's recording ring at a new size (new retention). Mirrors
+// _do_reset_storage but swaps in a caller-computed block geometry and reuses the
+// existing file paths. A fixed-size ring can't be resized in place, so this
+// clears the camera's existing recordings — the UI confirms before calling.
+static void _do_change_retention(
+    r_vss::r_stream_keeper& stream_keeper,
+    r_disco::r_devices& devices,
+    r_disco::r_camera camera,
+    int64_t new_num_blocks,
+    int64_t new_block_size,
+    storage_op_state& op
+)
+{
+    auto set_status = [&](const string& s) {
+        std::lock_guard<std::mutex> g(op.mtx);
+        op.status = s;
+    };
+
+    try
+    {
+        if(new_num_blocks <= 0 || new_block_size <= 0)
+            R_THROW(("Invalid retention size."));
+
+        stream_keeper.suspend(camera.id);
+
+        set_status("Deleting old recordings...");
+        _delete_camera_files(camera);
+        op.progress = 0.3f;
+
+        string nts_path;
+        string mdb_path;
+        if(!camera.record_file_path.is_null())
+            nts_path = _get_storage_path(camera.record_file_path.value());
+        if(!camera.motion_detection_file_path.is_null())
+            mdb_path = _get_storage_path(camera.motion_detection_file_path.value());
+
+        set_status("Allocating new storage file...");
+        if(!nts_path.empty())
+            r_storage::r_storage_file::allocate(nts_path, new_block_size, new_num_blocks);
+        op.progress = 0.7f;
+
+        if(!mdb_path.empty())
+            _create_motion_files(mdb_path);
+        op.progress = 0.9f;
+
+        set_status("Updating database...");
+        camera.n_record_file_blocks.set_value(new_num_blocks);
+        camera.record_file_block_size.set_value(new_block_size);
+        devices.save_camera(camera);
+
+        set_status("Retention updated. Recording will resume.");
         op.progress = 1.f;
         op.done = true;
         op.running = false;
@@ -1590,6 +1661,48 @@ void configure_camera_setup_wizard(
                         }
                     }
                     camera_setup_wizard.next("move_storage_modal");
+                },
+                [&](){
+                    // Change Retention button
+                    auto cid = ui_state.selected_camera_id();
+                    if(!cid.is_null())
+                    {
+                        auto maybe_camera = devices.get_camera_by_id(cid.value());
+                        if(!maybe_camera.is_null())
+                        {
+                            auto& c = maybe_camera.value();
+
+                            // Live bitrate drives the new ring size (same source
+                            // the recording list uses to show retention).
+                            int64_t bps = 0;
+                            for(auto& st : stream_keeper.fetch_stream_status())
+                            {
+                                if(st.camera.id == c.id) { bps = st.bytes_per_second; break; }
+                            }
+
+                            int64_t nb = c.n_record_file_blocks.is_null() ? 0 : c.n_record_file_blocks.value();
+                            int64_t bs = c.record_file_block_size.is_null() ? 0 : c.record_file_block_size.value();
+                            double cap_days = (bps > 0 && nb > 0 && bs > 0)
+                                ? ((double)(nb * bs) / (double)bps / 86400.0) : 0.0;
+
+                            s_storage_op.camera_id = c.id;
+                            s_storage_op.camera_name = c.friendly_name.is_null() ? c.camera_name.value() : c.friendly_name.value();
+                            s_storage_op.byte_rate = bps;
+                            s_storage_op.retention_days = (cap_days > 0.0) ? cap_days : 1.0;
+                            s_storage_op.new_num_blocks = nb;
+                            s_storage_op.new_block_size = bs;
+                            s_storage_op.running = false;
+                            s_storage_op.done = false;
+                            s_storage_op.error = false;
+                            s_storage_op.progress = 0.f;
+                            s_storage_op.delete_confirmed = false;
+                            {
+                                std::lock_guard<std::mutex> g(s_storage_op.mtx);
+                                s_storage_op.status.clear();
+                            }
+                        }
+                    }
+                    camera_setup_wizard.next("change_retention_modal");
                 }
             );
         }
@@ -1663,6 +1776,69 @@ void configure_camera_setup_wizard(
                 },
                 [&](){
                     // Cancel in-progress op: signal thread, then wait for done before closing
+                    s_storage_op.cancel_requested = true;
+                }
+            );
+        }
+    );
+
+    camera_setup_wizard.add_step(
+        "change_retention_modal",
+        [&camera_setup_wizard, &devices, &stream_keeper](){
+            ImGui::OpenPopup("Change Retention");
+
+            string status_copy;
+            {
+                std::lock_guard<std::mutex> g(s_storage_op.mtx);
+                status_copy = s_storage_op.status;
+            }
+
+            revere::change_retention_modal(
+                GImGui,
+                "Change Retention",
+                s_storage_op.camera_name,
+                s_storage_op.byte_rate,
+                s_storage_op.retention_days,
+                s_storage_op.delete_confirmed,
+                s_storage_op.new_num_blocks,
+                s_storage_op.new_block_size,
+                s_storage_op.progress.load(),
+                s_storage_op.running.load(),
+                s_storage_op.done.load(),
+                s_storage_op.error.load(),
+                status_copy,
+                [&](){
+                    auto maybe_camera = devices.get_camera_by_id(s_storage_op.camera_id);
+                    if(maybe_camera.is_null()) return;
+                    s_storage_op.running = true;
+                    s_storage_op.done = false;
+                    s_storage_op.error = false;
+                    s_storage_op.progress = 0.f;
+                    s_storage_op.cancel_requested = false;
+                    {
+                        std::lock_guard<std::mutex> g(s_storage_op.mtx);
+                        s_storage_op.status.clear();
+                    }
+                    auto camera = maybe_camera.value();
+                    int64_t nb = s_storage_op.new_num_blocks;
+                    int64_t bs = s_storage_op.new_block_size;
+                    std::thread([&stream_keeper, &devices, camera, nb, bs](){
+                        _do_change_retention(stream_keeper, devices, camera, nb, bs, s_storage_op);
+                    }).detach();
+                },
+                [&](){
+                    s_storage_op.running = false;
+                    s_storage_op.done = false;
+                    s_storage_op.error = false;
+                    s_storage_op.progress = 0.f;
+                    s_storage_op.delete_confirmed = false;
+                    {
+                        std::lock_guard<std::mutex> g(s_storage_op.mtx);
+                        s_storage_op.status.clear();
+                    }
+                    camera_setup_wizard.cancel();
+                },
+                [&](){
                     s_storage_op.cancel_requested = true;
                 }
             );

--- a/libs/r_storage/source/r_storage_file_reader.cpp
+++ b/libs/r_storage/source/r_storage_file_reader.cpp
@@ -3,6 +3,7 @@
 #include "r_utils/r_string_utils.h"
 #include "r_utils/r_blob_tree.h"
 #include "r_utils/r_logger.h"
+#include "r_utils/r_file.h"
 #include "r_utils/3rdparty/json/json.h"
 #include <algorithm>
 #include <memory>
@@ -18,10 +19,27 @@ r_storage_file_reader::r_storage_file_reader(const string& file_name) :
     _file_name(file_name)
 {
     auto base_name = file_name.substr(0, (file_name.find_last_of('.')));
-    
+
     // Use .nts extension for nanots files
     auto nanots_file_name = base_name + ".nts";
-    
+
+    // Guard against a truncated / zero-length .nts before handing it to nanots.
+    // nanots mmaps the header block and memcmps the "NTS\0" magic at offset 0
+    // *before* it can validate the file is large enough, so a short file faults
+    // (SIGBUS: "cluster_pagein past EOF") inside that read instead of failing
+    // cleanly with NANOTS_EC_BAD_MAGIC. A partially-allocated file can be left
+    // behind when a ring reallocation is interrupted (e.g. a crash mid
+    // fallocate). Every valid nanots file is at least one FILE_HEADER_BLOCK_SIZE
+    // header block, so reject anything smaller with a normal exception — which
+    // callers already handle (and which can't SIGBUS the whole process).
+    if(!r_fs::file_exists(nanots_file_name))
+        R_THROW(("nanots file not found: %s", nanots_file_name.c_str()));
+
+    auto nts_size = r_fs::file_size(nanots_file_name);
+    if(nts_size < FILE_HEADER_BLOCK_SIZE)
+        R_THROW(("nanots file truncated (%llu bytes < %d-byte header block): %s",
+                 (unsigned long long)nts_size, (int)FILE_HEADER_BLOCK_SIZE, nanots_file_name.c_str()));
+
     _reader = make_unique<nanots_reader>(nanots_file_name);
 }
 

--- a/libs/r_vss/source/r_stream_keeper.cpp
+++ b/libs/r_vss/source/r_stream_keeper.cpp
@@ -670,6 +670,18 @@ void r_stream_keeper::_entry_point()
                     {
                         rc->stop();
                         _motionEngine.remove_work_context(cmd.first.id);
+                        // Fully destroy the recording context here — before we ack the
+                        // suspend — so its nanots write context flushes and finalizes
+                        // the current segment against the SQLite DB while that DB still
+                        // exists. _streams held the only owning ref (see
+                        // _add_recording_contexts), so this reset runs the destructor
+                        // now. Otherwise suspend() returns while ~r_recording_context is
+                        // still pending on this thread, and a caller that immediately
+                        // deletes the camera's storage files (Change Retention, or Move
+                        // Storage "start fresh") races the destructor's
+                        // "UPDATE segment_blocks" finalize, which aborts the process on a
+                        // now-missing table.
+                        rc.reset();
                     }
 
                     cmd.second.set_value(result);


### PR DESCRIPTION
## Why

The card's "retention: N days" is the size of the preallocated recording ring (`file_bytes / bitrate`), and today it can only be set once, at camera setup. The Camera Properties dialog's "Minimum continuous retention hours" is a *motion-pruning floor*, not the ring size — so there was no way to reduce a camera's actual days/disk from the app without removing and re-adding it. This adds that.

## Change

- **"Change Retention" button** in the Camera Properties dialog opens a new `change_retention_modal`: enter retention days, see the resulting storage size live (sized from the camera's current bitrate × days — same math as the setup wizard's retention step).
- **`_do_change_retention`** reallocates the ring at the new geometry, reusing the same file paths, and updates the camera row's block counts. Mirrors the existing `_do_reset_storage` async op (suspend → delete old files → allocate → resume), so it reclaims disk immediately rather than orphaning the old file.
- A fixed-size ring can't be resized in place, so applying **clears that camera's existing recordings** — the modal states this and requires a confirm checkbox.
- Sizing needs a live bitrate, so **Apply is disabled (with an explanation) when the camera isn't receiving video**.

## Notes

- Desktop only (imgui). The web UI's Manage tab is unchanged.
- Verified it compiles clean against the app build flags (`-fsyntax-only` via the project's `compile_commands.json`).